### PR TITLE
Extract Message Factory from Events

### DIFF
--- a/src/slack/events/event.cr
+++ b/src/slack/events/event.cr
@@ -1,13 +1,12 @@
 class Slack::Event
   include JSON::Serializable
-  include Slack::SerializableEvent
 
   property type : String
 
   use_json_discriminator "type", {
     app_home_opened:  Slack::Events::AppHomeOpened,
     app_uninstalled:  Slack::Events::AppUninstalled,
-    message:          Slack::Events::Message,
+    message:          Slack::Events::MessageFactory,
     reaction_added:   Slack::Events::ReactionAdded,
     reaction_removed: Slack::Events::ReactionRemoved,
     tokens_revoked:   Slack::Events::TokensRevoked,

--- a/src/slack/events/event_types/message.cr
+++ b/src/slack/events/event_types/message.cr
@@ -1,11 +1,4 @@
 class Slack::Events::Message < Slack::Event
-  use_optional_discriminator "subtype", {
-    bot_add:         Slack::Events::Message::BotAdd,
-    channel_join:    Slack::Events::Message::ChannelJoin,
-    message_changed: Slack::Events::Message::MessageChanged,
-    message_deleted: Slack::Events::Message::MessageDeleted,
-  }
-
   property attachments : Array(Slack::EventData::Attachment)?,
     blocks : Array(JSON::Any),
     channel : String,

--- a/src/slack/events/event_types/message_factory.cr
+++ b/src/slack/events/event_types/message_factory.cr
@@ -1,0 +1,12 @@
+class Slack::Events::MessageFactory
+  include Slack::OptionalDiscriminator
+
+  use_optional_discriminator_on "subtype",
+    Slack::Events::Message,
+    {
+      bot_add:         Slack::Events::Message::BotAdd,
+      channel_join:    Slack::Events::Message::ChannelJoin,
+      message_changed: Slack::Events::Message::MessageChanged,
+      message_deleted: Slack::Events::Message::MessageDeleted,
+    }
+end

--- a/src/slack/mixins/optional_discriminator.cr
+++ b/src/slack/mixins/optional_discriminator.cr
@@ -1,5 +1,5 @@
-module Slack::SerializableEvent
-  macro use_optional_discriminator(field, mapping)
+module Slack::OptionalDiscriminator
+  macro use_optional_discriminator_on(field, default_type, mapping)
     {% unless mapping.is_a?(HashLiteral) || mapping.is_a?(NamedTupleLiteral) %}
       {% mapping.raise "mapping argument must be a HashLiteral or a NamedTupleLiteral, not #{mapping.class_name.id}" %}
     {% end %}
@@ -36,7 +36,7 @@ module Slack::SerializableEvent
       end
 
       unless discriminator_value
-        return self.new_from_json_pull_parser JSON::PullParser.new json
+        return {{default_type}}.from_json(json)
       end
 
       case discriminator_value


### PR DESCRIPTION
Mirror Slack's event "structure", allowing a single
type for new messages, and additional types based
on the presence of message + its optional subtypes.

Cleans up the interface to make it a little bit more
self-documenting.