### PR TITLE
Pass HTTP Client instances instead of class

### DIFF
--- a/spec/auth_handler_spec.cr
+++ b/spec/auth_handler_spec.cr
@@ -11,7 +11,7 @@ class StubClient < HTTP::Client
     properties_with_initializer body : String
   end
 
-  def self.post(**_kwargs)
+  def post(_url, **_args)
     StubResponse.new body: File.read("spec/fixtures/auth_success.json")
   end
 end
@@ -40,7 +40,7 @@ describe Slack::AuthHandler do
           headers: HTTP::Headers.new
         )
 
-        result = Slack::AuthHandler.run(request, StubClient)
+        result = Slack::AuthHandler.run(request, StubClient.new("example.com"))
         result.team.name.should eq "Slack Softball Team"
       end
     end

--- a/spec/fixtures/vcr/conversations-info-C032TLM43GA/7582fb10aa9685144677ccb45dc96810.vcr
+++ b/spec/fixtures/vcr/conversations-info-C032TLM43GA/7582fb10aa9685144677ccb45dc96810.vcr
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-date: Fri, 08 Apr 2022 01:01:43 GMT
+date: Fri, 08 Apr 2022 20:51:37 GMT
 server: Apache
 x-powered-by: HHVM/4.153.0
 access-control-allow-origin: *
@@ -8,24 +8,24 @@ x-slack-backend: r
 strict-transport-security: max-age=31536000; includeSubDomains; preload
 access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
 access-control-expose-headers: x-slack-req-id, retry-after
-x-oauth-scopes: app_mentions:read,channels:history,channels:read,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read,commands
+x-oauth-scopes: app_mentions:read,channels:history,channels:read,commands,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read
 x-accepted-oauth-scopes: channels:read,groups:read,mpim:read,im:read,read
 expires: Mon, 26 Jul 1997 05:00:00 GMT
 cache-control: private, no-cache, no-store, must-revalidate
 pragma: no-cache
 x-xss-protection: 0
 x-content-type-options: nosniff
-x-slack-req-id: 1cbbf4c3be4e8724877e82930ec294da
+x-slack-req-id: 0df644d4603b500e51de16dc9fda504d
 vary: Accept-Encoding
 content-type: application/json; charset=utf-8
-x-envoy-upstream-service-time: 103
+x-envoy-upstream-service-time: 97
 x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
-x-server: slack-www-hhvm-main-iad-ekma
+x-server: slack-www-hhvm-main-iad-6c8w
 x-slack-shared-secret-outcome: no-match
-via: envoy-www-iad-f6ja, envoy-edge-pdx-iv52
+via: envoy-www-iad-rel3, envoy-edge-pdx-4fge
 x-edge-backend: envoy-www
 x-slack-edge-shared-secret-outcome: no-match
 connection: close
-Content-Length: 634
+Content-Length: 603
 
-{"ok":true,"channel":{"id":"C032TLM43GA","name":"links","is_channel":true,"is_group":false,"is_im":false,"is_mpim":false,"is_private":false,"created":1644634963,"is_archived":false,"is_general":false,"unlinked":0,"name_normalized":"links","is_shared":false,"is_org_shared":false,"is_pending_ext_shared":false,"pending_shared":[],"parent_conversation":null,"creator":"U016SQZLFEE","is_ext_shared":false,"shared_team_ids":["T017GL5AV5E"],"pending_connected_team_ids":[],"is_member":true,"last_read":"1646886284.912189","topic":{"value":"","creator":"","last_set":0},"purpose":{"value":"","creator":"","last_set":0},"previous_names":[]}}
+{"ok":true,"channel":{"id":"C032TLM43GA","name":"links","is_channel":true,"is_group":false,"is_im":false,"is_mpim":false,"is_private":false,"created":1644634963,"is_archived":false,"is_general":false,"unlinked":0,"name_normalized":"links","is_shared":false,"is_org_shared":false,"is_pending_ext_shared":false,"pending_shared":[],"parent_conversation":null,"creator":"U016SQZLFEE","is_ext_shared":false,"shared_team_ids":["T017GL5AV5E"],"pending_connected_team_ids":[],"is_member":false,"topic":{"value":"","creator":"","last_set":0},"purpose":{"value":"","creator":"","last_set":0},"previous_names":[]}}

--- a/spec/fixtures/vcr/conversations-info-D031PUW2YG5/d789e01c08200efab0e277a382de1b63.vcr
+++ b/spec/fixtures/vcr/conversations-info-D031PUW2YG5/d789e01c08200efab0e277a382de1b63.vcr
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-date: Fri, 08 Apr 2022 01:01:43 GMT
+date: Fri, 08 Apr 2022 20:51:37 GMT
 server: Apache
 x-powered-by: HHVM/4.153.0
 access-control-allow-origin: *
@@ -8,21 +8,21 @@ x-slack-backend: r
 strict-transport-security: max-age=31536000; includeSubDomains; preload
 access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
 access-control-expose-headers: x-slack-req-id, retry-after
-x-oauth-scopes: app_mentions:read,channels:history,channels:read,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read,commands
+x-oauth-scopes: app_mentions:read,channels:history,channels:read,commands,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read
 x-accepted-oauth-scopes: channels:read,groups:read,mpim:read,im:read,read
 expires: Mon, 26 Jul 1997 05:00:00 GMT
 cache-control: private, no-cache, no-store, must-revalidate
 pragma: no-cache
 x-xss-protection: 0
 x-content-type-options: nosniff
-x-slack-req-id: ec7164b439ba6921315abf900af09342
+x-slack-req-id: 9073e4b265dbd9f0b7b00129fec3e75b
 vary: Accept-Encoding
 content-type: application/json; charset=utf-8
-x-envoy-upstream-service-time: 137
+x-envoy-upstream-service-time: 105
 x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
-x-server: slack-www-hhvm-main-iad-inj2
+x-server: slack-www-hhvm-main-iad-bdi2
 x-slack-shared-secret-outcome: no-match
-via: envoy-www-iad-czmm, envoy-edge-pdx-sv7g
+via: envoy-www-iad-b2fn, envoy-edge-pdx-9fi7
 x-edge-backend: envoy-www
 x-slack-edge-shared-secret-outcome: no-match
 connection: close

--- a/spec/fixtures/vcr/team-info-success/aa0cd2182d44af01bcd01e86ab43af37.vcr
+++ b/spec/fixtures/vcr/team-info-success/aa0cd2182d44af01bcd01e86ab43af37.vcr
@@ -1,5 +1,5 @@
 HTTP/1.1 200 OK
-date: Fri, 08 Apr 2022 01:01:43 GMT
+date: Fri, 08 Apr 2022 20:51:37 GMT
 server: Apache
 x-powered-by: HHVM/4.153.0
 access-control-allow-origin: *
@@ -8,21 +8,21 @@ x-slack-backend: r
 strict-transport-security: max-age=31536000; includeSubDomains; preload
 access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
 access-control-expose-headers: x-slack-req-id, retry-after
-x-oauth-scopes: app_mentions:read,channels:history,channels:read,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read,commands
+x-oauth-scopes: app_mentions:read,channels:history,channels:read,commands,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read
 x-accepted-oauth-scopes: team:read
 expires: Mon, 26 Jul 1997 05:00:00 GMT
 cache-control: private, no-cache, no-store, must-revalidate
 pragma: no-cache
 x-xss-protection: 0
 x-content-type-options: nosniff
-x-slack-req-id: 79ff6fa5d7e150d430451bd9ac8bc1a7
+x-slack-req-id: 5b44f09dcd96c3b7b487a2dd914285f9
 vary: Accept-Encoding
 content-type: application/json; charset=utf-8
-x-envoy-upstream-service-time: 78
+x-envoy-upstream-service-time: 83
 x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
-x-server: slack-www-hhvm-main-iad-7s95
+x-server: slack-www-hhvm-main-iad-5rit
 x-slack-shared-secret-outcome: no-match
-via: envoy-www-iad-s5tx, envoy-edge-pdx-4geg
+via: envoy-www-iad-crwy, envoy-edge-pdx-y8mn
 x-edge-backend: envoy-www
 x-slack-edge-shared-secret-outcome: no-match
 connection: close

--- a/src/slack/models/conversations/public_channel.cr
+++ b/src/slack/models/conversations/public_channel.cr
@@ -18,7 +18,7 @@ struct Slack::Models::PublicChannel < Slack::Models::ConversationType
     unread_count : Int16?
 
   @[JSON::Field(converter: Slack::DecimalTimeStampConverter)]
-  property last_read : Time
+  property last_read : Time?
 
   def self.from_json(json : String | IO)
     keyed_json_object(json, find_key: "channel")


### PR DESCRIPTION
Resolves issues when handling HTTP Clients inherited from lucky
apps.