### PR TITLE
Decorate Events with team_id

### DIFF
--- a/spec/slack_spec.cr
+++ b/spec/slack_spec.cr
@@ -140,6 +140,7 @@ describe Slack do
         ],
         "event": {
           "type": "reaction_removed",
+          "team_id": "T017GL5AV5E",
           "item": {
             "ts": "1644728351.305109",
             "type": "message",

--- a/src/slack.cr
+++ b/src/slack.cr
@@ -46,7 +46,6 @@ module Slack
 
   def self.from_json(json : String | IO)
     pull = JSON::PullParser.new(json)
-    original = JSON::PullParser.new(json)
     default = nil
 
     pull.read_object do |key|
@@ -59,6 +58,6 @@ module Slack
       end
     end
 
-    default || Slack::VerifiedEvent.new(original)
+    default || Slack::VerifiedEvent.from_json(json)
   end
 end

--- a/src/slack/event.cr
+++ b/src/slack/event.cr
@@ -1,7 +1,7 @@
 abstract class Slack::Event
   include JSON::Serializable
 
-  property type : String
+  property type : String, team_id : String?
 
   use_json_discriminator "type", {
     app_home_opened:  Slack::Events::AppHomeOpened,

--- a/src/slack/events/verified_event.cr
+++ b/src/slack/events/verified_event.cr
@@ -13,4 +13,8 @@ class Slack::VerifiedEvent
 
   @[JSON::Field(converter: Time::EpochConverter)]
   properties_with_initializer event_time : Time
+
+  def after_initialize
+    @event.team_id = team_id
+  end
 end


### PR DESCRIPTION
Adding this makes it much easier to determine
which webhooks belong to which workspaces.

Allows applications to build different behavior
into webhook listening & parsing on a per-workspace
basis.