### PR TITLE
Remove API deprecations + fix serialization errors

### DIFF
--- a/src/slack/api/endpoints/chat_post_message.cr
+++ b/src/slack/api/endpoints/chat_post_message.cr
@@ -29,9 +29,8 @@ class Slack::Api::ChatPostMessage < Slack::Api::Base
 
   # Extract this into a configuration object.
   #
-  # Options -- https://api.slack.com/methods/chat.postMessage#arg_as_user
+  # Options -- https://api.slack.com/methods/chat.postMessage
   properties_with_initializer \
-    as_user : Bool? = false,
     icon_emoji : String?,
     icon_url : String?,
     link_names : Bool?,

--- a/src/slack/events/event_types/message/message_deleted.cr
+++ b/src/slack/events/event_types/message/message_deleted.cr
@@ -1,3 +1,3 @@
 class Slack::Events::Message::MessageDeleted < Slack::Events::MessageSubtype
-  property hidden : Bool, previous_message : Slack::EventData::MessageSubset
+  property hidden : Bool, previous_message : Slack::EventData::MessageSubset?
 end


### PR DESCRIPTION
as_user is deprecated; Slack now requires posting with the
token of the bot or the token of the user when posting
messages.

The previous_message param isn't always included in a
deleted message notification and can trigger serialization
errors, so should be treated as optional.