### PR TITLE
Add reactions

### DIFF
--- a/spec/api/conversations_history_spec.cr
+++ b/spec/api/conversations_history_spec.cr
@@ -1,0 +1,23 @@
+require "../spec_helper"
+
+describe Slack::Api::ConversationsHistory do
+  describe "#call" do
+    it "should post a chat message with one block" do
+      token = ENV.fetch("SLACK_TEAM_AUTH_TOKEN")
+
+      load_cassette("conversations-history-success") do
+        response = Slack::Api::ConversationsHistory
+          .new(token: token, channel: "C03B5PUPDSQ")
+          .call
+          .should be_a(Slack::Models::ConversationsHistory)
+
+        files = response
+          .messages[1]
+          .files
+          .should be_a(Array(Hash(String, JSON::Any)))
+
+        files.first["id"].should eq "F03EAJ1UXFZ"
+      end
+    end
+  end
+end

--- a/spec/api/reactions_add_spec.cr
+++ b/spec/api/reactions_add_spec.cr
@@ -1,0 +1,19 @@
+require "../spec_helper"
+
+describe Slack::Api::ReactionsAdd do
+  describe "#call" do
+    it "should request the reactions add resource from the API" do
+      load_cassette("reactions-add-success") do
+        channel = "C03B5PUPDSQ"
+        ts = "1652146092.815149"
+        reaction = "t-rex"
+        token = ENV.fetch("SLACK_TEAM_AUTH_TOKEN")
+        response = Slack::Api::ReactionsAdd
+          .new(token: token, name: reaction, channel: channel, timestamp: ts)
+          .call
+          .should be_a(Slack::Models::DefaultResponse)
+        response.ok.should be_true
+      end
+    end
+  end
+end

--- a/spec/fixtures/app_config/app_manifest.json
+++ b/spec/fixtures/app_config/app_manifest.json
@@ -42,6 +42,7 @@
                 "im:read",
                 "mpim:read",
                 "reactions:read",
+                "reactions:write",
                 "team:read",
                 "users:read"
             ]

--- a/spec/fixtures/vcr/apps-update-manifest-success/4e15f8035f9ce0a47d97fe8a976492cb.vcr
+++ b/spec/fixtures/vcr/apps-update-manifest-success/4e15f8035f9ce0a47d97fe8a976492cb.vcr
@@ -1,0 +1,31 @@
+HTTP/1.1 200 OK
+date: Sat, 07 May 2022 02:38:36 GMT
+server: Apache
+x-powered-by: HHVM/4.153.1
+access-control-allow-origin: *
+referrer-policy: no-referrer
+x-slack-backend: r
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
+access-control-expose-headers: x-slack-req-id, retry-after
+x-oauth-scopes: identify,app_configurations:read,app_configurations:write
+x-accepted-oauth-scopes: app_configurations:write
+expires: Mon, 26 Jul 1997 05:00:00 GMT
+cache-control: private, no-cache, no-store, must-revalidate
+pragma: no-cache
+x-xss-protection: 0
+x-content-type-options: nosniff
+x-slack-req-id: 241b0040494709374e36b63b8bf91832
+vary: Accept-Encoding
+content-type: application/json; charset=utf-8
+x-envoy-upstream-service-time: 293
+x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
+x-server: slack-www-hhvm-main-iad-rh2r
+x-slack-shared-secret-outcome: no-match
+via: envoy-www-iad-67xx, envoy-edge-pdx-11xz
+x-edge-backend: envoy-www
+x-slack-edge-shared-secret-outcome: no-match
+connection: close
+Content-Length: 62
+
+{"ok":true,"app_id":"FAKEAPPID","permissions_updated":true}

--- a/spec/fixtures/vcr/conversations-history-success/b23ad22bd3aeb8bbd67690a67e4637f7.vcr
+++ b/spec/fixtures/vcr/conversations-history-success/b23ad22bd3aeb8bbd67690a67e4637f7.vcr
@@ -1,0 +1,31 @@
+HTTP/1.1 200 OK
+date: Tue, 10 May 2022 01:33:32 GMT
+server: Apache
+x-powered-by: HHVM/4.153.1
+access-control-allow-origin: *
+referrer-policy: no-referrer
+x-slack-backend: r
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
+access-control-expose-headers: x-slack-req-id, retry-after
+x-oauth-scopes: app_mentions:read,channels:history,channels:read,chat:write,chat:write.public,commands,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read,reactions:write
+x-accepted-oauth-scopes: channels:history,groups:history,mpim:history,im:history,read
+expires: Mon, 26 Jul 1997 05:00:00 GMT
+cache-control: private, no-cache, no-store, must-revalidate
+pragma: no-cache
+x-xss-protection: 0
+x-content-type-options: nosniff
+x-slack-req-id: ad4f935e92946fd7f79a718d9df3654d
+vary: Accept-Encoding
+content-type: application/json; charset=utf-8
+x-envoy-upstream-service-time: 186
+x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
+x-server: slack-www-hhvm-main-iad-m7gh
+x-slack-shared-secret-outcome: no-match
+via: envoy-www-iad-6lh8, envoy-edge-pdx-4j8f
+x-edge-backend: envoy-www
+x-slack-edge-shared-secret-outcome: no-match
+connection: close
+Content-Length: 3784
+
+{"ok":true,"messages":[{"client_msg_id":"7f053a40-57ad-4e7c-ba82-4aae36ba2784","type":"message","text":":broom:","user":"U016SQZLFEE","ts":"1652146092.815149","team":"T017GL5AV5E","blocks":[{"type":"rich_text","block_id":"NVz2P","elements":[{"type":"rich_text_section","elements":[{"type":"emoji","name":"broom"}]}]}],"thread_ts":"1652146092.815149","reply_count":3,"reply_users_count":2,"latest_reply":"1652146125.426989","reply_users":["U03B6E5AHJM","U016SQZLFEE"],"is_locked":false,"subscribed":false},{"type":"message","text":"one with an image","files":[{"id":"F03EAJ1UXFZ","created":1652146080,"timestamp":1652146080,"name":"Screen Shot 2022-05-09 at 8.21.45 AM.png","title":"Screen Shot 2022-05-09 at 8.21.45 AM.png","mimetype":"image\/png","filetype":"png","pretty_type":"PNG","user":"U016SQZLFEE","editable":false,"size":19298,"mode":"hosted","is_external":false,"external_type":"","is_public":true,"public_url_shared":false,"display_as_bot":false,"username":"","url_private":"https:\/\/files.slack.com\/files-pri\/T017GL5AV5E-F03EAJ1UXFZ\/screen_shot_2022-05-09_at_8.21.45_am.png","url_private_download":"https:\/\/files.slack.com\/files-pri\/T017GL5AV5E-F03EAJ1UXFZ\/download\/screen_shot_2022-05-09_at_8.21.45_am.png","media_display_type":"unknown","thumb_64":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_64.png","thumb_80":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_80.png","thumb_360":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_360.png","thumb_360_w":360,"thumb_360_h":45,"thumb_480":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_480.png","thumb_480_w":480,"thumb_480_h":59,"thumb_160":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_160.png","thumb_720":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_720.png","thumb_720_w":720,"thumb_720_h":89,"thumb_800":"https:\/\/files.slack.com\/files-tmb\/T017GL5AV5E-F03EAJ1UXFZ-1eae1ee076\/screen_shot_2022-05-09_at_8.21.45_am_800.png","thumb_800_w":800,"thumb_800_h":99,"original_w":904,"original_h":112,"thumb_tiny":"AwAFADC8Ebc37w08KQMFiaB1b606gBMe5ox7miigAx7mj86KKAP\/2Q==","permalink":"https:\/\/goalsurfer.slack.com\/files\/U016SQZLFEE\/F03EAJ1UXFZ\/screen_shot_2022-05-09_at_8.21.45_am.png","permalink_public":"https:\/\/slack-files.com\/T017GL5AV5E-F03EAJ1UXFZ-70ead60409","is_starred":false,"has_rich_preview":false}],"upload":false,"user":"U016SQZLFEE","display_as_bot":false,"ts":"1652146084.366209","blocks":[{"type":"rich_text","block_id":"TnB","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"one with an image"}]}]}],"client_msg_id":"c2866602-c528-4e32-b7a9-32f09bd9afbb","thread_ts":"1652146084.366209","reply_count":1,"reply_users_count":1,"latest_reply":"1652146085.365079","reply_users":["U03B6E5AHJM"],"is_locked":false,"subscribed":false},{"client_msg_id":"645ac2c7-2099-499f-8efa-42f900fc16cd","type":"message","text":"adding some message types for the bot again, whoops","user":"U016SQZLFEE","ts":"1652146074.758869","team":"T017GL5AV5E","blocks":[{"type":"rich_text","block_id":"4+35G","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"adding some message types for the bot again, whoops"}]}]}],"thread_ts":"1652146074.758869","reply_count":1,"reply_users_count":1,"latest_reply":"1652146076.164999","reply_users":["U03B6E5AHJM"],"is_locked":false,"subscribed":false}],"has_more":false,"pin_count":0,"channel_actions_ts":null,"channel_actions_count":0}

--- a/spec/fixtures/vcr/reactions-add-success/55cd4bbb4940a4430da3877ee1471d7a.vcr
+++ b/spec/fixtures/vcr/reactions-add-success/55cd4bbb4940a4430da3877ee1471d7a.vcr
@@ -1,31 +1,31 @@
 HTTP/1.1 200 OK
-date: Mon, 18 Apr 2022 19:33:09 GMT
+date: Tue, 10 May 2022 23:13:58 GMT
 server: Apache
-x-powered-by: HHVM/4.153.0
+x-powered-by: HHVM/4.153.1
 access-control-allow-origin: *
 referrer-policy: no-referrer
 x-slack-backend: r
 strict-transport-security: max-age=31536000; includeSubDomains; preload
 access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
 access-control-expose-headers: x-slack-req-id, retry-after
-x-oauth-scopes: identify,app_configurations:read,app_configurations:write
-x-accepted-oauth-scopes: app_configurations:write
+x-oauth-scopes: app_mentions:read,channels:history,channels:read,chat:write,chat:write.public,commands,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read,reactions:write
+x-accepted-oauth-scopes: reactions:write
 expires: Mon, 26 Jul 1997 05:00:00 GMT
 cache-control: private, no-cache, no-store, must-revalidate
 pragma: no-cache
 x-xss-protection: 0
 x-content-type-options: nosniff
-x-slack-req-id: 7c78960284ac882ed80018f097b0ffde
+x-slack-req-id: 1a675267d14b8aeba01cdacc2771935a
 vary: Accept-Encoding
 content-type: application/json; charset=utf-8
-x-envoy-upstream-service-time: 237
+x-envoy-upstream-service-time: 118
 x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
-x-server: slack-www-hhvm-main-iad-adoq
+x-server: slack-www-hhvm-main-iad-kabg
 x-slack-shared-secret-outcome: no-match
-via: envoy-www-iad-gn7k, envoy-edge-pdx-7a74
+via: envoy-www-iad-g08p, envoy-edge-pdx-lgoc
 x-edge-backend: envoy-www
 x-slack-edge-shared-secret-outcome: no-match
 connection: close
-Content-Length: 62
+Content-Length: 11
 
-{"ok":true,"app_id":"A03B17S326M","permissions_updated":false}
+{"ok":true}

--- a/spec/fixtures/vcr/reactions-add-success/f26b74555f0bb0e5f8a05a17646d3c8f.vcr
+++ b/spec/fixtures/vcr/reactions-add-success/f26b74555f0bb0e5f8a05a17646d3c8f.vcr
@@ -1,31 +1,31 @@
 HTTP/1.1 200 OK
-date: Mon, 18 Apr 2022 19:33:09 GMT
+date: Tue, 10 May 2022 23:13:58 GMT
 server: Apache
-x-powered-by: HHVM/4.153.0
+x-powered-by: HHVM/4.153.1
 access-control-allow-origin: *
 referrer-policy: no-referrer
 x-slack-backend: r
 strict-transport-security: max-age=31536000; includeSubDomains; preload
 access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
 access-control-expose-headers: x-slack-req-id, retry-after
-x-oauth-scopes: identify,app_configurations:read,app_configurations:write
-x-accepted-oauth-scopes: app_configurations:write
+x-oauth-scopes: app_mentions:read,channels:history,channels:read,chat:write,chat:write.public,commands,groups:history,groups:read,im:history,im:read,mpim:read,reactions:read,team:read,users:read,reactions:write
+x-accepted-oauth-scopes: reactions:write
 expires: Mon, 26 Jul 1997 05:00:00 GMT
 cache-control: private, no-cache, no-store, must-revalidate
 pragma: no-cache
 x-xss-protection: 0
 x-content-type-options: nosniff
-x-slack-req-id: 7c78960284ac882ed80018f097b0ffde
+x-slack-req-id: 1a675267d14b8aeba01cdacc2771935a
 vary: Accept-Encoding
 content-type: application/json; charset=utf-8
-x-envoy-upstream-service-time: 237
+x-envoy-upstream-service-time: 118
 x-backend: main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow main_control_with_overflow main_bedrock_control_with_overflow
-x-server: slack-www-hhvm-main-iad-adoq
+x-server: slack-www-hhvm-main-iad-kabg
 x-slack-shared-secret-outcome: no-match
-via: envoy-www-iad-gn7k, envoy-edge-pdx-7a74
+via: envoy-www-iad-g08p, envoy-edge-pdx-lgoc
 x-edge-backend: envoy-www
 x-slack-edge-shared-secret-outcome: no-match
 connection: close
-Content-Length: 62
+Content-Length: 11
 
-{"ok":true,"app_id":"FAKEAPPID","permissions_updated":false}
+{"ok":true}

--- a/src/slack/api/endpoints/chat_post_message.cr
+++ b/src/slack/api/endpoints/chat_post_message.cr
@@ -29,9 +29,8 @@ class Slack::Api::ChatPostMessage < Slack::Api::Base
 
   # Extract this into a configuration object.
   #
-  # Options -- https://api.slack.com/methods/chat.postMessage#arg_as_user
+  # Options -- https://api.slack.com/methods/chat.postMessage
   properties_with_initializer \
-    as_user : Bool? = false,
     icon_emoji : String?,
     icon_url : String?,
     link_names : Bool?,

--- a/src/slack/api/endpoints/conversations_history.cr
+++ b/src/slack/api/endpoints/conversations_history.cr
@@ -1,0 +1,35 @@
+# https://api.slack.com/methods/conversations.history
+class Slack::Api::ConversationsHistory < Slack::Api::Base
+  properties_with_initializer \
+    channel : String,
+    cursor : String?,
+    include_all_metadata : Bool = false,
+    inclusive : Bool = false,
+    latest : String?,
+    oldest : String?,
+    token : String
+
+  def content_type : ContentTypes
+    ContentTypes::JSON
+  end
+
+  def base_url
+    "https://slack.com/api/conversations.history?#{url_params}"
+  end
+
+  def url_params
+    HTTP::Params.build do |form|
+      form.add "channel", channel
+      form.add "cursor", cursor if cursor
+      form.add "include_all_metadata", include_all_metadata.to_s
+      form.add "inclusive", inclusive.to_s
+      form.add "latest", latest if latest
+      form.add "oldest", oldest if oldest
+    end
+  end
+
+  def call : Slack::Models::ConversationsHistory
+    result = HTTP::Client.get(url: base_url, headers: headers, body: to_json)
+    ResponseHandler(Models::ConversationsHistory).from_json(result.body)
+  end
+end

--- a/src/slack/api/endpoints/reactions_add.cr
+++ b/src/slack/api/endpoints/reactions_add.cr
@@ -1,0 +1,21 @@
+# https://api.slack.com/methods/reactions.add
+class Slack::Api::ReactionsAdd < Slack::Api::Base
+  properties_with_initializer \
+    channel : String,
+    name : String,
+    token : String,
+    timestamp : String
+
+  def content_type : ContentTypes
+    ContentTypes::JSON
+  end
+
+  def base_url
+    "https://slack.com/api/reactions.add"
+  end
+
+  def call : Slack::Models::DefaultResponse
+    result = HTTP::Client.post(url: base_url, headers: headers, body: to_json)
+    ResponseHandler(Slack::Models::DefaultResponse).from_json(result.body)
+  end
+end

--- a/src/slack/event.cr
+++ b/src/slack/event.cr
@@ -1,5 +1,6 @@
 abstract class Slack::Event
   include JSON::Serializable
+  include Slack::JSONRecords
 
   property type : String, team_id : String?
 

--- a/src/slack/events/event_types/message/message_deleted.cr
+++ b/src/slack/events/event_types/message/message_deleted.cr
@@ -1,3 +1,3 @@
 class Slack::Events::Message::MessageDeleted < Slack::Events::MessageSubtype
-  property hidden : Bool, previous_message : Slack::EventData::MessageSubset
+  property hidden : Bool, previous_message : Slack::EventData::MessageSubset?
 end

--- a/src/slack/events/event_types/reaction_added.cr
+++ b/src/slack/events/event_types/reaction_added.cr
@@ -1,8 +1,5 @@
 class Slack::Events::ReactionAdded < Slack::Event
-  struct ReactionItem
-    include JSON::Serializable
-    property ts : String, type : String, channel : String
-  end
+  json_record ReactionItem, ts : String, type : String, channel : String
 
   property item : ReactionItem,
     item_user : String,

--- a/src/slack/mixins/json_records.cr
+++ b/src/slack/mixins/json_records.cr
@@ -1,0 +1,10 @@
+module Slack::JSONRecords
+  macro json_record(klass, *type_declarations)
+    struct {{ klass.id }}
+      include JSON::Serializable
+      include Slack::InitializerMacros
+
+      properties_with_initializer {{ *type_declarations }}
+    end
+  end
+end

--- a/src/slack/model.cr
+++ b/src/slack/model.cr
@@ -1,6 +1,7 @@
 abstract struct Slack::Model
   include JSON::Serializable
   include Slack::InitializerMacros
+  include Slack::JSONRecords
 
   def self.keyed_json_object(json : String | IO, find_key : String, &block)
     pull = JSON::PullParser.new(json)

--- a/src/slack/models/conversations/conversations_history.cr
+++ b/src/slack/models/conversations/conversations_history.cr
@@ -1,0 +1,22 @@
+struct Slack::Models::ConversationsHistory < Slack::Model
+  json_record ResponseMetadata, cursor : String
+
+  json_record MessageHistory,
+    blocks : Array(Hash(String, JSON::Any))?,
+    files : Array(Hash(String, JSON::Any))?,
+    latest_reply : String?,
+    reply_count : Int32?,
+    reply_users : Array(String)?,
+    reply_users_count : Int32?,
+    text : String?,
+    thread_ts : String,
+    ts : String,
+    type : String,
+    user : String?
+
+  properties_with_initializer \
+    messages : Array(MessageHistory),
+    has_more : Bool,
+    pin_count : Int32,
+    response_metadata : ResponseMetadata?
+end

--- a/src/slack/models/default_response.cr
+++ b/src/slack/models/default_response.cr
@@ -1,0 +1,4 @@
+# Used for Slack response objects that only include { ok: true }.
+struct Slack::Models::DefaultResponse < Slack::Model
+  property ok : Bool
+end

--- a/src/slack/ui/component.cr
+++ b/src/slack/ui/component.cr
@@ -1,5 +1,6 @@
 abstract class Slack::UI::Component
   include Slack::UI::BaseComponents
+  include Slack::JSONRecords
 end
 
 abstract class Slack::UI::BaseComponent < Slack::UI::Component

--- a/src/slack/ui/components/button_actions.cr
+++ b/src/slack/ui/components/button_actions.cr
@@ -1,11 +1,7 @@
 class Slack::UI::Components::ButtonActions < Slack::UI::BaseComponent
   alias Styles = BlockElements::Button::Styles
 
-  struct ButtonData
-    include Slack::InitializerMacros
-
-    properties_with_initializer text : String, style : Styles?
-  end
+  json_record ButtonData, text : String, style : Styles?
 
   def self.render(
     action_id : String,


### PR DESCRIPTION
This started as a mission to add support reactions, but in order to allow for some early performance benchmarking, ended up including a couple other features, including:

– conversations history" support
– a refactored JSON record macro for serializable in-line Structs
– bug fixes for overly strict JSON Typings