### PR TITLE
Add base support for Sign in With Slack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.3.2
+          crystal: 1.7.2
 
       - name: Format
         run: crystal tool format --check
@@ -29,14 +29,7 @@ jobs:
       fail-fast: true
       matrix:
         crystal_version:
-          - 1.3.0
-          - 1.4.0
           - latest
-        experimental:
-          - false
-        include:
-          - crystal_version: nightly
-            experimental: true
     steps:
       - uses: actions/checkout@v2.4.0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.4.0
+          crystal: 1.7.2
       - name: "Install shards"
         run: shards install
       - name: "Generate docs"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ end
 Slack::AuthHandler.configure do |config|
   config.oauth_redirect_url = ENV["OAUTH_REDIRECT_URL"]
 end
+
+# To enable "Sign in with Slack," you'll need to configure
+# Slack's OpenID Connecion handling.
+Slack::SignIn.configure do |config|
+  config.sign_in_redirect_url = ENV["SIGN_IN_REDIRECT_URL"]
+end
 ```
 
 ### Processing Webhook Events

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 authors:
   - Rob Cole <robcole@gmail.com>
 
-crystal: 1.4.0
+crystal: 1.7.2
 
 license: MIT
 
@@ -21,7 +21,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.3
+    version: ~> 1.4.2
   lucky_env:
     github: luckyframework/lucky_env
   vcr:

--- a/spec/api/apps_update_manifest_spec.cr
+++ b/spec/api/apps_update_manifest_spec.cr
@@ -14,7 +14,7 @@ describe Slack::Api::AppsManifestUpdate do
           .should be_a(Slack::Models::Apps::ManifestUpdate)
 
         response.app_id.should eq app_id
-        response.ok.should be_true
+        response.ok?.should be_true
       end
     end
   end

--- a/spec/api/chat_post_message_spec.cr
+++ b/spec/api/chat_post_message_spec.cr
@@ -14,7 +14,7 @@ describe Slack::Api::ChatPostMessage do
           .post_blocks(token: token, channel: channel_id, blocks: [section])
           .should be_a(Slack::Models::Chat::PostMessage)
 
-        response.ok.should be_true
+        response.ok?.should be_true
         response.channel.should eq channel_id
         response.message["bot_id"].should eq "B03ATRRPV4K"
       end
@@ -35,7 +35,7 @@ describe Slack::Api::ChatPostMessage do
           .post_blocks(token: token, channel: channel_id, blocks: [section, actions])
           .should be_a(Slack::Models::Chat::PostMessage)
 
-        response.ok.should be_true
+        response.ok?.should be_true
         response.channel.should eq channel_id
         response.message["bot_id"].should eq "B03ATRRPV4K"
       end

--- a/spec/api/reactions_add_spec.cr
+++ b/spec/api/reactions_add_spec.cr
@@ -12,7 +12,7 @@ describe Slack::Api::ReactionsAdd do
           .new(token: token, name: reaction, channel: channel, timestamp: ts)
           .call
           .should be_a(Slack::Models::DefaultResponse)
-        response.ok.should be_true
+        response.ok?.should be_true
       end
     end
   end

--- a/src/slack/api/response_handler.cr
+++ b/src/slack/api/response_handler.cr
@@ -1,5 +1,5 @@
 struct Slack::Api::ResponseHandler(ResponseModel)
-  def self.from_json(json : String | IO, &block) : ResponseModel
+  def self.from_json(json : String | IO, &) : ResponseModel
     pull = JSON::PullParser.new(json)
 
     pull.read_object do |key|

--- a/src/slack/events/event_types/message/message_changed.cr
+++ b/src/slack/events/event_types/message/message_changed.cr
@@ -1,8 +1,9 @@
 struct Slack::Events::Message::MessageChanged < Slack::Event
   include Slack::Events::MessageSubtype
 
-  property hidden : Bool,
-    previous_message : Slack::EventData::MessageSubset?,
+  property previous_message : Slack::EventData::MessageSubset?,
     message : Slack::EventData::MessageSubset,
     text : String?
+
+  property? hidden = false
 end

--- a/src/slack/events/event_types/message/message_deleted.cr
+++ b/src/slack/events/event_types/message/message_deleted.cr
@@ -1,5 +1,7 @@
 struct Slack::Events::Message::MessageDeleted < Slack::Event
   include Slack::Events::MessageSubtype
 
-  property hidden : Bool, previous_message : Slack::EventData::MessageSubset?
+  property previous_message : Slack::EventData::MessageSubset?
+
+  property? hidden = false
 end

--- a/src/slack/model.cr
+++ b/src/slack/model.cr
@@ -3,7 +3,7 @@ abstract struct Slack::Model
   include Slack::InitializerMacros
   include Slack::JSONRecords
 
-  def self.keyed_json_object(json : String | IO, find_key : String, &block)
+  def self.keyed_json_object(json : String | IO, find_key : String, &)
     pull = JSON::PullParser.new(json)
     return_value = nil
     pull.read_object do |key|

--- a/src/slack/models/apps/manifest_update.cr
+++ b/src/slack/models/apps/manifest_update.cr
@@ -1,6 +1,7 @@
 struct Slack::Models::Apps::ManifestUpdate < Slack::Model
   properties_with_initializer \
     app_id : String,
-    ok : Bool,
     permissions_updated : Bool
+
+  property? ok = true
 end

--- a/src/slack/models/chat/delete.cr
+++ b/src/slack/models/chat/delete.cr
@@ -1,3 +1,5 @@
 struct Slack::Models::Chat::Delete < Slack::Model
-  properties_with_initializer channel : String, ok : Bool, ts : String
+  properties_with_initializer channel : String, ts : String
+
+  property? ok = true
 end

--- a/src/slack/models/chat/post_message.cr
+++ b/src/slack/models/chat/post_message.cr
@@ -1,7 +1,8 @@
 struct Slack::Models::Chat::PostMessage < Slack::Model
   properties_with_initializer \
-    ok : Bool,
     channel : String?,
     message : JSON::Any,
     ts : String
+
+  property? ok = true
 end

--- a/src/slack/models/conversations/subtypes/im_chat.cr
+++ b/src/slack/models/conversations/subtypes/im_chat.cr
@@ -1,8 +1,9 @@
 struct Slack::Models::IMChat < Slack::Models::Conversation
   property id : String,
-    is_im : Bool,
     latest : Slack::Models::DirectMessage,
     user : String
+
+  property? is_im = true
 
   def self.from_json(json : String | IO)
     keyed_json_object(json, find_key: "channel")

--- a/src/slack/models/conversations/subtypes/public_channel.cr
+++ b/src/slack/models/conversations/subtypes/public_channel.cr
@@ -1,13 +1,6 @@
 struct Slack::Models::PublicChannel < Slack::Models::Conversation
   property creator : String,
     id : String,
-    is_archived : Bool,
-    is_general : Bool,
-    is_member : Bool,
-    is_mpim : Bool,
-    is_org_shared : Bool,
-    is_private : Bool,
-    is_shared : Bool,
     members : Array(String)?,
     name : String,
     name_normalized : String,
@@ -16,6 +9,14 @@ struct Slack::Models::PublicChannel < Slack::Models::Conversation
     topic : JSON::Any,
     unread_count_display : Int16?,
     unread_count : Int16?
+
+  property? is_archived = false,
+    is_general = false,
+    is_member = false,
+    is_mpim = false,
+    is_org_shared = false,
+    is_private = false,
+    is_shared = false
 
   @[JSON::Field(converter: Slack::DecimalTimeStampConverter)]
   property last_read : Time?

--- a/src/slack/models/default_response.cr
+++ b/src/slack/models/default_response.cr
@@ -1,4 +1,4 @@
 # Used for Slack response objects that only include { ok: true }.
 struct Slack::Models::DefaultResponse < Slack::Model
-  property ok : Bool
+  property? ok = true
 end

--- a/src/slack/models/team/team.cr
+++ b/src/slack/models/team/team.cr
@@ -4,8 +4,8 @@ struct Slack::Models::Team < Slack::Model
     email_domain : String,
     icon : JSON::Any,
     id : String,
-    is_verified : Bool,
     name : String,
+    is_verified : Bool,
     url : String
 
   def self.from_json(json : String | IO)

--- a/src/slack/models/views/views_open.cr
+++ b/src/slack/models/views/views_open.cr
@@ -1,3 +1,5 @@
 struct Slack::Models::ViewsOpen < Slack::Model
-  properties_with_initializer ok : Bool, view : JSON::Any
+  properties_with_initializer view : JSON::Any
+
+  property? ok = true
 end

--- a/src/slack/oauth/auth_response.cr
+++ b/src/slack/oauth/auth_response.cr
@@ -7,11 +7,12 @@ struct Slack::AuthResponse
     bot_user_id : String?,
     enterprise : Slack::Auth::Enterprise?,
     expires_in : Int32?,
-    ok : Bool,
     refresh_token : String?,
     scope : String,
     team : Slack::Auth::Team,
     token_type : String?
+
+  property? ok = true
 
   def self.from_json(json : String | IO)
     pull = JSON::PullParser.new(json)

--- a/src/slack/oauth/sign_in_response.cr
+++ b/src/slack/oauth/sign_in_response.cr
@@ -1,0 +1,74 @@
+struct Slack::SignInResponse
+  include JSON::Serializable
+
+  struct DecodedResponse
+    include JSON::Serializable
+
+    property \
+      at_hash : String,
+      email : String,
+      family_name : String,
+      given_name : String,
+      iss : String,
+      locale : String,
+      name : String,
+      nonce : String,
+      picture : String,
+      sub : String
+
+    property? email_verified = false
+
+    # TODO: Turn these all into proper Time objects
+    property aud : String
+    property auth_time : Int64
+    property date_email_verified : Int64
+    property exp : Int64
+    property iat : Int64
+
+    @[JSON::Field(key: "https://slack.com/team_domain")]
+    property team_domain : String
+
+    @[JSON::Field(key: "https://slack.com/team_id")]
+    property team_id : String
+
+    @[JSON::Field(key: "https://slack.com/team_name")]
+    property team_name : String
+
+    @[JSON::Field(key: "https://slack.com/user_id")]
+    property user_id : String
+  end
+
+  property \
+    access_token : String,
+    id_token : String,
+    token_type : String
+
+  property? ok = true
+
+  def decoded_response
+    DecodedResponse.from_json(
+      JWT.decode(id_token, verify: false, validate: false)[0].to_json
+    )
+  end
+
+  def self.from_json(json : String | IO)
+    pull = JSON::PullParser.new(json)
+    return_value = nil
+    pull.read_object do |key|
+      case key
+      when "ok"
+        value = pull.read_bool
+        case value
+        when true
+          return_value = new JSON::PullParser.new(json)
+        else
+          raise Errors::Auth.new(json)
+        end
+      else
+        pull.skip
+      end
+    end
+
+    return_value || raise Errors::Auth.new(json)
+  end
+end

--- a/src/slack/oauth/sign_in_with_slack.cr
+++ b/src/slack/oauth/sign_in_with_slack.cr
@@ -1,0 +1,72 @@
+# https://api.slack.com/authentication/sign-in-with-slack
+class Slack::SignInWithSlack
+  Habitat.create do
+    setting sign_in_redirect_url : String = ENV["SIGN_IN_REDIRECT_URL"]
+    setting scopes : Array(String) = [
+      "openid",
+      "email",
+      "profile",
+    ]
+  end
+
+  delegate bot_scopes, client_id, client_secret, user_scopes, to: Slack.settings
+
+  property http_client
+
+  def initialize(client : HTTP::Client)
+    @http_client = client
+  end
+
+  def initialize(client : Nil)
+    @http_client = default_client
+  end
+
+  def initialize
+    @http_client = default_client
+  end
+
+  private def default_client
+    HTTP::Client.new("slack.com", port: 443, tls: true)
+  end
+
+  def self.run(request : HTTP::Request, http_client = nil)
+    new(http_client).authenticate_user(request)
+  end
+
+  def redirect_url
+    params = HTTP::Params.encode({
+      client_id:     client_id,
+      scope:         settings.scopes.join(" "),
+      redirect_uri:  settings.sign_in_redirect_url,
+      response_type: "code",
+    })
+
+    URI.decode_www_form(
+      URI.new("https", "slack.com/openid/connect/authorize", query: params).to_s
+    )
+  end
+
+  def authenticate_user(request : HTTP::Request)
+    code = request.query_params["code"]
+    headers = HTTP::Headers.new
+    headers["Content-Type"] = ContentTypes::FormEncoded.to_s
+    headers["Accept"] = ContentTypes::JSON.to_s
+
+    # TODO: add state and nonce to the request to prevent CSRF and replay attacks
+    # TODO: add a team scope to the request to limit the user to a specific team,
+    # and to allow the user to easily login to multiple teams
+    response = http_client.post(
+      "/api/openid.connect.token",
+      headers: headers,
+      form: URI::Params.encode({
+        code:          code,
+        client_id:     client_id,
+        client_secret: client_secret,
+        grant_type:    "authorization_code",
+        redirect_uri:  settings.sign_in_redirect_url,
+      })
+    )
+
+    Slack::SignInResponse.from_json(response.body).decoded_response
+  end
+end

--- a/src/slack/webhooks/verified_request.cr
+++ b/src/slack/webhooks/verified_request.cr
@@ -12,7 +12,10 @@ struct Slack::Webhooks::VerifiedRequest
   def initialize(@request : HTTP::Request)
     @slack_timestamp = @request.headers["X-Slack-Request-Timestamp"]
     @slack_signature = @request.headers["X-Slack-Signature"]
+
+    # ameba:disable Lint/NotNil
     @body = @request.body.not_nil!.gets_to_end
+    # ameba:enable Lint/NotNil
   end
 
   def verify!


### PR DESCRIPTION
Adds the ability for users to authenticate to an
app directly from Slack, to expose basic profile
info (email, profile, etc).

Resolves https://github.com/the-business-factory/slack.cr/issues/30