### PR TITLE
Ignore local planning documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 .DS_Store
 .env
+
+# Local modernization audit and issue drafts
+/plans/


### PR DESCRIPTION
Ignore the repository-root `plans/` directory so local modernization audits and issue drafts can stay in the workspace without being committed. This PR contains only the `.gitignore` rule; the planning documents remain local.

Validated with `git check-ignore` for all eight planning documents and `git diff --check`.
