### PR TITLE
Add worktree setup script for shared plans and shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 .env
 
 # Local modernization audit and issue drafts
-/plans/
+/plans

--- a/scripts/setup-worktree.sh
+++ b/scripts/setup-worktree.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+worktree_root=$(git -C "$script_dir/.." rev-parse --show-toplevel)
+# Git lists the main worktree first. Preserve spaces in its path.
+main_root=$(git -C "$worktree_root" worktree list --porcelain | sed -n '1s/^worktree //p')
+plans_source="$main_root/plans"
+plans_target="$worktree_root/plans"
+
+if [[ ! -d "$plans_source" ]]; then
+  printf 'Missing main-worktree plans directory: %s\n' "$plans_source" >&2
+  exit 1
+fi
+
+if [[ "$worktree_root" != "$main_root" ]]; then
+  if [[ -L "$plans_target" && "$plans_target" -ef "$plans_source" ]]; then
+    printf 'Plans already linked to %s\n' "$plans_source"
+  elif [[ -e "$plans_target" || -L "$plans_target" ]]; then
+    printf 'Refusing to replace existing plans path: %s\n' "$plans_target" >&2
+    exit 1
+  else
+    ln -s "$plans_source" "$plans_target"
+    printf 'Linked plans to %s\n' "$plans_source"
+  fi
+fi
+
+cd -- "$worktree_root"
+shards install


### PR DESCRIPTION
New worktrees do not inherit the ignored planning files. Add `bash scripts/setup-worktree.sh` to link each worktree’s `plans/` to the main worktree’s directory and run `shards install`. Repeated setup retains the correct link; conflicting existing paths are preserved and reported as errors.

Update `.gitignore` to cover both a plans directory and a symlink.

Validation: shell syntax check, successful initial setup and rerun, symlink ignore check, and `git diff --check`. No Crystal source changed.
