### PR TITLE
Define authentication storage and refresh contracts

### DIFF
--- a/documentation/auth-contracts.md
+++ b/documentation/auth-contracts.md
@@ -1,0 +1,170 @@
+# Authentication contracts
+
+These interfaces define how authentication services share state, credentials, and HTTP access. Require the contract entry point directly:
+
+```crystal
+require "./src/slack/auth/contracts"
+
+clock : Slack::Auth::Clock = Slack::Auth::SystemClock.new
+key : Slack::Auth::InstallationKey = Slack::Auth::InstallationKey.new(
+  "A1", :workspace, team_id: "T1"
+)
+query : Slack::Auth::InstallationQuery = Slack::Auth::InstallationQuery.new(
+  key, Slack::Auth::GrantKey.new(:bot)
+)
+```
+
+Run this example from the repository root. It creates a query, not an authenticated request. Applications can still supply tokens directly to the existing API client.
+
+Concrete storage adapters, HTTP clients, and authentication services are separate work. These contracts do not enable Sign in with Slack.
+
+## Time and authorization state
+
+Inject a `Clock`; `SystemClock#now` returns UTC. Each store must use an authoritative clock for expiry, leases, and credential checks. Across processes, use database transaction time or an equivalent shared clock. Do not rely on client clocks with unknown differences.
+
+State and credentials expire when `expires_at <= now`. The rotation service sets the refresh margin. It can acquire a reference to an expired grant, but it cannot use that grant for an API request.
+
+An `AuthorizationAttempt` contains state, session binding, purpose, expiry, redirect URI, and an optional OIDC nonce.
+
+- The installation service generates cryptographically random state.
+- The application supplies trusted session binding. Do not read it from callback parameters.
+- The server controls the redirect URI.
+- OIDC attempts require a separate random nonce. Installation attempts reject a nonce.
+- A session can have several active attempts, such as separate browser tabs.
+
+The constructor stores data. It does not generate state or verify a callback.
+
+`StateStore#issue` inserts a new attempt. A collision must fail without replacing the existing attempt. `consume` checks state, session, purpose, and expiry, then deletes the matching attempt in one atomic operation. Invalid input raises `ContractError` with code `InvalidState`. A mismatch must not delete a valid attempt.
+
+For an application that already has a configured `state_store` and trusted inputs:
+
+```crystal
+attempt : Slack::Auth::AuthorizationAttempt = state_store.consume(
+  returned_state, session_binding, Slack::Auth::AuthorizationPurpose::Installation
+)
+# Exchange the callback code only after consume succeeds.
+```
+
+The state remains consumed if code exchange fails. Start a new authorization attempt; do not reuse the callback code.
+
+## Installation and grant identity
+
+An `InstallationKey` contains the exact app, installation kind, enterprise, and team IDs. Empty IDs are invalid.
+
+| Installation kind | Required ID | Other ID rules |
+| --- | --- | --- |
+| Workspace | Team | Enterprise can be absent. |
+| Organization | Enterprise | Team must be absent. |
+
+Resolve one trusted installation owner before creating an `InstallationQuery`. There is no wildcard lookup or fallback to another installation. Keep the actor user and visible team as separate metadata. A visible workspace is not part of an organization installation key.
+
+A `GrantKey` selects a bot grant or one explicit user ID:
+
+```crystal
+bot_key : Slack::Auth::GrantKey = Slack::Auth::GrantKey.new(:bot)
+user_key : Slack::Auth::GrantKey = Slack::Auth::GrantKey.new(:user, "U1")
+```
+
+App-level tokens and app-configuration tokens are outside this model.
+
+A `Grant` contains the subject ID, access token, scopes, optional refresh token, and absolute expiry. A bot grant uses the bot's authenticated user ID as its subject. The authorization service can obtain additional identity data through `auth.test`. Each user-map key must match its grant's subject ID.
+
+Bot and user grants have separate lifecycles. `IncomingWebhook` contains its bearer URL, channel ID, and optional configuration URL. Parsing and validation of Slack responses remain separate responsibilities.
+
+`InstallationPatch` replaces only the supplied bot, users, and webhook values. Omitted values preserve existing data. Use explicit invalidation to remove credentials. Snapshot collections are copied so callers cannot change stored data through a returned value.
+
+## Store versions and deletion
+
+Every `InstallationStore` operation must be atomic and durable across processes. Operations must have one consistent order visible to all callers.
+
+A `Version` identifies the record revision and installation generation. A generation identifies one installation lifecycle. A tombstone is the retained record of a deleted installation.
+
+| Operation | Required behavior |
+| --- | --- |
+| `fetch` | Return an active snapshot, a tombstone, or `nil` if the key never existed. |
+| `store` | Compare the complete expected version. With `nil`, insert only if no record or tombstone exists. |
+| Active update | Increase the record revision. Replace only supplied grants, increase their revisions, and cancel their refresh ownership. |
+| Reinstall | Compare the tombstone version and increase the generation. Do not restore deleted grants. |
+| `invalidate` | Compare the record version. Remove only the selected grant and invalidate its refresh ownership. Preserve other grant revisions. |
+| `delete` | Compare the version. Remove all credentials, webhook data, and refresh ownership. Retain a tombstone with increased generation and revision. |
+
+Record revisions increase across deletion and reinstall. Each replacement grant receives a revision that was never used for that installation. Generations must never repeat. Reject counter overflow. Do not remove stored history if that can allow an old generation to be reused.
+
+Missing data, stale versions, and storage errors raise `ContractError`. They must not select another tenant or return a successful mutation. An atomic storage failure leaves the previous state intact. If the commit result is lost, read the stored version and ownership to determine what happened. Do not assume rollback.
+
+Duplicate or delayed revocation events need the expected version or generation for the affected installation. The store cannot infer an event's original generation from its arrival time. The lifecycle service must handle event order and duplicates. It must not fetch a new reinstall version just to apply an old revocation. If an event cannot identify the intended generation, the service needs an explicit conservative policy.
+
+## Refresh ownership
+
+Coordinate refresh by installation and `GrantKey`, including the user ID. A lease contains the installation generation, grant revision, increasing fence value, and deadline. The fence lets the store reject an old owner after ownership changes.
+
+A lease is not a secret and does not authorize access to another tenant. Every transition checks the complete lease and credential version in one transaction. A mutex in one process does not satisfy this requirement across processes.
+
+1. Call `acquire(query)` for a credential reference.
+2. Call `claim_refresh(reference, duration)` with a positive duration. The store checks the generation, grant revision, and refresh token. It assigns `Acquired` ownership atomically. Other callers receive `RefreshBusy`.
+3. Persist `mark_refresh_dispatched(lease)` before sending HTTP. Only the current, unexpired `Acquired` owner can do this. If the storage result is uncertain, determine the stored state before sending. The transport sends one request without automatic retries or redirects.
+4. On success, call `complete_refresh(lease, replacement)`. The subject must remain the same. The store accepts only the current, unexpired `Dispatched` owner. It saves the replacement and clears ownership atomically. Changes to other grants must survive and must not prevent completion solely because the record revision changed.
+5. On definite rejection, call `fail_refresh(lease, Rejected)`. This removes the grant. On an uncertain remote result, use `UnknownRemoteOutcome`. This keeps `Uncertain` ownership and blocks use of the grant. Neither result permits a blind refresh retry.
+
+An unexpired `Acquired` owner can call `release_refresh` only if it sent no request.
+
+| Expired ownership | Recovery |
+| --- | --- |
+| `Acquired` | Assign a new owner with a new fence. The required pre-send transition did not occur. |
+| `Dispatched` | Change to `Uncertain`. Do not send the old refresh token again. |
+
+A crash after marking `Dispatched` but before sending also blocks the grant. This can require a new authorization, but prevents use of a one-time refresh token twice.
+
+## Uncertain results and revocation races
+
+`refresh_status` applies expiry changes atomically before returning ownership. `Uncertain` ownership does not clear automatically. A new authorization, targeted invalidation, or uninstall/reinstall can replace it. There is no operation to retry the old token manually.
+
+Reject late completion after lease expiry, even when it includes a successful remote response.
+
+A successful response followed by a storage failure produces `PersistenceFailure`. Keep replacement credentials secure and read the stored state. Retry only local persistence while the original fence and lease remain valid. After expiry or uncertain ownership, require new authorization. If completion committed but its acknowledgment was lost, the increased grant revision can show that result. Never repeat the remote refresh request to recover a storage result.
+
+Revocation and refresh completion follow their atomic transaction order:
+
+- If revocation occurs first, it removes the grant and invalidates the lease. Old refresh completion fails.
+- If completion occurs first, it increases the revision. An old revocation version conflicts. The lifecycle service must check the event's intended generation.
+- Reinstall changes the generation. A previous refresh cannot restore old credentials.
+
+## Credential checks before HTTP requests
+
+Request contexts retain `CredentialReference`, not a token they can reuse indefinitely. Immediately before each HTTP send, including an allowed retry, call `credential_for_dispatch`.
+
+For an application with a configured `store` and `query`:
+
+```crystal
+reference : Slack::Auth::CredentialReference = store.acquire(query)
+token : Slack::Auth::Secret = store.credential_for_dispatch(reference)
+# Use token.value for the immediate HTTP send. Do not log it.
+```
+
+The check verifies generation, grant revision, existence, expiry, and refresh state. `Dispatched` refresh blocks the call with `RefreshBusy`. `Uncertain` ownership blocks it with `UnknownRemoteOutcome`. Do not use a cached token if the check fails.
+
+This atomic check determines whether a request can proceed. A revocation completed before the check prevents the send. A revocation after the check cannot recall an admitted request. Do not put queued work, waits, refreshes, or user callbacks between the check and send. A queued job must acquire and check credentials when it sends.
+
+Storage and Slack HTTP cannot form one atomic transaction. Callers that supply tokens directly remain responsible for their token lifecycle.
+
+## Transport and safe errors
+
+`Transport#execute` takes a method, URI, headers, and body. It returns status, headers, and body once. Use `TransportFailure` only when the request was definitely not sent. Use `UnknownRemoteOutcome` when it might have been sent.
+
+`TransportFactory#build` accepts connect, read, and write timeouts, proxy settings, and CA configuration. Concrete implementations must validate these settings, TLS policy, and endpoint URLs. Contracts do not read global environment variables.
+
+API, OAuth authorization/token/redirect, and future OIDC discovery/issuer settings are separate. Future OIDC must obtain keys from validated discovery. Endpoint configuration alone does not verify identity.
+
+`ContractError` contains an allowed error code, optional HTTP status, and retry delay. It must not contain remote bodies, raw exception causes, headers, or tokens. Response handlers must map allowed remote codes to typed failures and parse String or IO input only once. Do not copy arbitrary remote text into diagnostics.
+
+`Secret` hides its value in `inspect` and `to_s`. Use `.value` explicitly to send or store it. Transport diagnostics hide bodies, headers, and URIs. Do not log configuration or URI objects. Secret wrappers do not encrypt data or erase memory.
+
+## Adapter validation
+
+Applications own production storage, encryption at rest, access controls, and safe logging.
+
+`AuthSupport::ProtocolStore` is a sequential test model. Its hash maps do not implement concurrent or durable storage. Its tests cover method usage and operation order, not production guarantees.
+
+A durable test adapter must verify transactions, atomic state consumption, version checks, grant isolation, lease recovery, storage failures, stale-owner rejection, restart, and contention between separate processes. Use deterministic synchronization and bounded waits.
+
+The contract tests use synthetic data and make no live requests. They do not prove durable rollback, recovery from lost acknowledgments, cross-process coordination, endpoint validation, or complete authentication flows. OIDC verification and existing-token migration remain deferred.

--- a/spec/auth/contracts_spec.cr
+++ b/spec/auth/contracts_spec.cr
@@ -1,0 +1,211 @@
+require "../spec_helper"
+require "../support/auth/protocol_store"
+
+private def present(value)
+  value || raise "Expected a contract value"
+end
+
+private def secret(value = "synthetic-token")
+  Slack::Auth::Secret.new(value)
+end
+
+private def grant(id = "B1", value = "synthetic-token")
+  Slack::Auth::Grant.new(id, secret(value), ["chat:write"], refresh_token: secret("synthetic-refresh"))
+end
+
+private def key(team = "T1")
+  Slack::Auth::InstallationKey.new("A1", :workspace, team_id: team)
+end
+
+private def query(team = "T1", user : String? = nil)
+  Slack::Auth::InstallationQuery.new(key(team), Slack::Auth::GrantKey.new(user ? Slack::Auth::TokenKind::User : Slack::Auth::TokenKind::Bot, user),
+    actor_user_id: "external-actor", visible_team_id: "external-team")
+end
+
+private def protocol
+  clock = AuthSupport::FakeClock.new
+  store = AuthSupport::ProtocolStore.new(clock)
+  store.store(key, Slack::Auth::InstallationPatch.new(bot: grant), nil)
+  {store, clock}
+end
+
+private def error(code : Slack::Auth::ErrorCode, &)
+  failure = expect_raises(Slack::Auth::ContractError) { yield }
+  failure.code.should eq(code)
+end
+
+describe "authentication contracts" do
+  it "supports the shared clock and rejects ambiguous installation/token keys" do
+    Slack::Auth::SystemClock.new.now.location.should eq(Time::Location::UTC)
+    error(:invalid_identity) { Slack::Auth::InstallationKey.new("A", :workspace) }
+    error(:invalid_identity) { Slack::Auth::InstallationKey.new("A", :organization, "E", "T") }
+    Slack::Auth::InstallationKey.new("A", :organization, "E").team_id.should be_nil
+    error(:invalid_identity) { Slack::Auth::GrantKey.new(:user) }
+    error(:invalid_identity) { Slack::Auth::GrantKey.new(:bot, "U") }
+  end
+
+  it "requires a nonce only for future OIDC attempts" do
+    clock = AuthSupport::FakeClock.new
+    error(:invalid_configuration) do
+      Slack::Auth::AuthorizationAttempt.new(secret, secret, :oidc, clock.now, "https://example.test/callback")
+    end
+    attempt = Slack::Auth::AuthorizationAttempt.new(secret, secret, :oidc, clock.now,
+      "https://example.test/callback", secret("nonce"))
+    present(attempt.nonce).value.should eq("nonce")
+  end
+
+  it "consumes state atomically with session, purpose, expiry and independent tabs" do
+    clock = AuthSupport::FakeClock.new
+    store = AuthSupport::StateStore.new(clock)
+    ["tab1", "tab2"].each do |state|
+      store.issue(Slack::Auth::AuthorizationAttempt.new(secret(state), secret("session"), :installation,
+        clock.now + 1.minute, "https://example.test/callback"))
+    end
+    error(:invalid_state) { store.consume(secret("tab1"), secret("other"), :installation) }
+    error(:invalid_state) { store.consume(secret("tab1"), secret("session"), :oidc) }
+    results = Channel(Bool).new
+    2.times do
+      spawn do
+        store.consume(secret("tab1"), secret("session"), :installation)
+        results.send(true)
+      rescue Slack::Auth::ContractError
+        results.send(false)
+      end
+    end
+    [results.receive, results.receive].count(true).should eq(1)
+    store.consume(secret("tab2"), secret("session"), :installation).state.value.should eq("tab2")
+    store.issue(Slack::Auth::AuthorizationAttempt.new(secret("expired"), secret("session"), :installation,
+      clock.now, "https://example.test/callback"))
+    error(:invalid_state) { store.consume(secret("expired"), secret("session"), :installation) }
+  end
+
+  it "rejects state collisions without overwriting the original attempt" do
+    clock = AuthSupport::FakeClock.new
+    store = AuthSupport::StateStore.new(clock)
+    attempt = Slack::Auth::AuthorizationAttempt.new(secret, secret("session"), :installation,
+      clock.now + 1.minute, "https://example.test/callback")
+    store.issue(attempt)
+    error(:conflict) { store.issue(attempt) }
+    store.consume(secret, secret("session"), :installation).should eq(attempt)
+  end
+
+  it "preserves separate users and tenants and uses explicit ownership" do
+    store, _ = protocol
+    record = present(store.fetch(key))
+    patch = Slack::Auth::InstallationPatch.new(users: {"U1" => grant("U1"), "U2" => grant("U2")})
+    record = store.store(key, patch, record.version)
+    store.store(key("T2"), Slack::Auth::InstallationPatch.new(bot: grant("B2", "tenant-two")), nil)
+    record = store.store(key, Slack::Auth::InstallationPatch.new(users: {"U1" => grant("U1", "updated")}), record.version)
+    record.users.keys.sort!.should eq(["U1", "U2"])
+    store.credential_for_dispatch(store.acquire(query("T1", "U1"))).value.should eq("updated")
+    store.credential_for_dispatch(store.acquire(query("T2"))).value.should eq("tenant-two")
+    error(:missing_installation) { store.acquire(query("missing")) }
+    error(:missing_grant) { store.acquire(query("T2", "U1")) }
+    error(:conflict) { store.store(key, patch, nil) }
+    record.users.clear
+    record.users.size.should eq(2)
+  end
+
+  it "reclaims only expired pre-dispatch ownership and fences the old holder" do
+    store, clock = protocol
+    reference = store.acquire(query)
+    first = store.claim_refresh(reference, 1.minute)
+    error(:refresh_busy) { store.claim_refresh(reference, 1.minute) }
+    clock.now += 1.minute
+    second = store.claim_refresh(reference, 1.minute)
+    second.fence.should be > first.fence
+    error(:conflict) { store.mark_refresh_dispatched(first) }
+    store.release_refresh(second)
+    store.refresh_status(query).should be_nil
+  end
+
+  it "quarantines a crashed dispatched refresh without a blind retry" do
+    store, clock = protocol
+    reference = store.acquire(query)
+    lease = store.claim_refresh(reference, 1.minute)
+    store.mark_refresh_dispatched(lease)
+    error(:refresh_busy) { store.credential_for_dispatch(reference) }
+    clock.now += 1.minute
+    error(:unknown_remote_outcome) { store.claim_refresh(reference, 1.minute) }
+    error(:unknown_remote_outcome) { store.credential_for_dispatch(reference) }
+    error(:conflict) { store.complete_refresh(lease, grant("B1", "late")) }
+    error(:conflict) { store.release_refresh(lease) }
+  end
+
+  it "persists successful rotation and rejects the old credential reference" do
+    store, _ = protocol
+    reference = store.acquire(query)
+    lease = store.claim_refresh(reference, 1.minute)
+    error(:conflict) { store.complete_refresh(lease, grant) }
+    store.mark_refresh_dispatched(lease)
+    record = store.complete_refresh(lease, grant("B1", "rotated"))
+    present(record.bot).grant.access_token.value.should eq("rotated")
+    error(:conflict) { store.credential_for_dispatch(reference) }
+    store.credential_for_dispatch(store.acquire(query)).value.should eq("rotated")
+    error(:conflict) { store.complete_refresh(lease, grant) }
+  end
+
+  it "separates rejected refresh from unknown remote outcome" do
+    [Slack::Auth::RefreshFailure::Rejected, Slack::Auth::RefreshFailure::UnknownRemoteOutcome].each do |failure|
+      store, _ = protocol
+      reference = store.acquire(query)
+      lease = store.claim_refresh(reference, 1.minute)
+      store.mark_refresh_dispatched(lease)
+      store.fail_refresh(lease, failure)
+      if failure.rejected?
+        error(:missing_grant) { store.acquire(query) }
+      else
+        error(:unknown_remote_outcome) { store.claim_refresh(reference, 1.minute) }
+      end
+    end
+  end
+
+  it "cannot resurrect revoked credentials or cross reinstall generations" do
+    store, _ = protocol
+    reference = store.acquire(query)
+    lease = store.claim_refresh(reference, 1.minute)
+    store.mark_refresh_dispatched(lease)
+    record = store.invalidate(key, query.grant, present(store.fetch(key)).version)
+    error(:conflict) { store.complete_refresh(lease, grant) }
+    error(:conflict) { store.credential_for_dispatch(reference) }
+    tombstone = store.delete(key, record.version)
+    tombstone.deleted?.should be_true
+    replacement = store.store(key, Slack::Auth::InstallationPatch.new(bot: grant), tombstone.version)
+    replacement.version.generation.should be > reference.generation
+    error(:conflict) { store.complete_refresh(lease, grant) }
+    error(:conflict) { store.delete(key, record.version) }
+    store.credential_for_dispatch(store.acquire(query)).value.should eq("synthetic-token")
+  end
+
+  it "allows independent grants to refresh and rejects tokens at expiry" do
+    store, clock = protocol
+    store.store(key, Slack::Auth::InstallationPatch.new(users: {"U1" => grant("U1")}), present(store.fetch(key)).version)
+    bot = store.claim_refresh(store.acquire(query), 1.minute)
+    user = store.claim_refresh(store.acquire(query("T1", "U1")), 1.minute)
+    store.mark_refresh_dispatched(bot)
+    store.mark_refresh_dispatched(user)
+    store.complete_refresh(bot, grant)
+    store.complete_refresh(user, Slack::Auth::Grant.new("U1", secret, [] of String, expires_at: clock.now))
+    error(:reauthorization_required) { store.credential_for_dispatch(store.acquire(query("T1", "U1"))) }
+  end
+
+  it "supports observable offline transport and redacts sensitive diagnostics" do
+    transport = AuthSupport::RecordingTransport.new
+    response = Slack::Auth::TransportResponse.new(200, HTTP::Headers.new, "canary-response")
+    transport.enqueue(response)
+    request = Slack::Auth::TransportRequest.new("POST", URI.parse("https://example.test/token?code=canary"),
+      HTTP::Headers{"Authorization" => "canary-header"}, "canary-body")
+    transport.execute(request).should eq(response)
+    transport.requests.first.body.should eq("canary-body")
+    error(:transport_failure) { transport.execute(request) }
+    [request.inspect, request.to_s, response.inspect, response.to_s, grant("B1", "canary").inspect,
+     Slack::Auth::ContractError.new(:invalid_response, 429, 1.second).inspect].each do |diagnostic|
+      diagnostic.should_not contain("canary")
+    end
+    Slack::Auth::APIConfiguration.new(URI.parse("https://example.test/api/")).base_uri.host.should eq("example.test")
+    Slack::Auth::OAuthConfiguration.new(URI.parse("https://example.test/authorize"), URI.parse("https://example.test/token"),
+      "A1", secret, URI.parse("https://example.test/callback")).client_id.should eq("A1")
+    Slack::Auth::OIDCConfiguration.new(URI.parse("https://example.test/discovery"), "issuer", "A1").issuer.should eq("issuer")
+    Slack::Auth::TransportOptions.new.read_timeout.should eq(30.seconds)
+  end
+end

--- a/spec/support/auth/fakes.cr
+++ b/spec/support/auth/fakes.cr
@@ -1,0 +1,52 @@
+require "../../../src/slack/auth/contracts"
+
+module AuthSupport
+  class FakeClock < Slack::Auth::Clock
+    property now : Time
+
+    def initialize(@now = Time.utc(2026, 1, 1))
+    end
+  end
+
+  class StateStore < Slack::Auth::StateStore
+    @attempts = {} of String => Slack::Auth::AuthorizationAttempt
+    @mutex = Mutex.new
+
+    def initialize(@clock : Slack::Auth::Clock)
+    end
+
+    def issue(attempt : Slack::Auth::AuthorizationAttempt) : Nil
+      @mutex.synchronize do
+        raise Slack::Auth::ContractError.new(:conflict) if @attempts.has_key?(attempt.state.value)
+        @attempts[attempt.state.value] = attempt
+      end
+    end
+
+    def consume(state : Slack::Auth::Secret, session_binding : Slack::Auth::Secret,
+                purpose : Slack::Auth::AuthorizationPurpose) : Slack::Auth::AuthorizationAttempt
+      @mutex.synchronize do
+        attempt = @attempts[state.value]?
+        unless attempt && attempt.session_binding.value == session_binding.value &&
+               attempt.purpose == purpose && attempt.expires_at > @clock.now
+          raise Slack::Auth::ContractError.new(:invalid_state)
+        end
+        @attempts.delete(state.value)
+        attempt
+      end
+    end
+  end
+
+  class RecordingTransport < Slack::Auth::Transport
+    getter requests = [] of Slack::Auth::TransportRequest
+    @responses = [] of Slack::Auth::TransportResponse
+
+    def enqueue(response : Slack::Auth::TransportResponse) : Nil
+      @responses << response
+    end
+
+    def execute(request : Slack::Auth::TransportRequest) : Slack::Auth::TransportResponse
+      @requests << request
+      @responses.shift? || raise Slack::Auth::ContractError.new(:transport_failure)
+    end
+  end
+end

--- a/spec/support/auth/protocol_store.cr
+++ b/spec/support/auth/protocol_store.cr
@@ -1,0 +1,167 @@
+require "./fakes"
+
+# Sequential executable protocol model, NOT the reference/durable adapter owned by D.
+# It intentionally makes no cross-process or thread-safety claim.
+module AuthSupport
+  class ProtocolStore < Slack::Auth::InstallationStore
+    include Slack::Auth
+
+    @records = {} of InstallationKey => InstallationRecord
+    @ownership = {} of Tuple(InstallationKey, GrantKey) => RefreshOwnership
+    @fence = 0_i64
+
+    def initialize(@clock : Clock)
+    end
+
+    def fetch(key : InstallationKey) : InstallationRecord?
+      @records[key]?
+    end
+
+    def store(key : InstallationKey, patch : InstallationPatch, expected : Version?) : InstallationRecord
+      old = fetch(key)
+      raise ContractError.new(:conflict) unless old.try(&.version) == expected
+      generation = old ? old.version.generation + (old.deleted? ? 1 : 0) : 1_i64
+      revision = (old.try(&.version.revision) || 0_i64) + 1
+      previous = old unless old.try(&.deleted?)
+      users = previous.try(&.users) || {} of String => StoredGrant
+      bot = previous.try(&.bot)
+      if grant = patch.bot
+        bot = StoredGrant.new(grant, revision)
+        @ownership.delete({key, GrantKey.new(:bot)})
+      end
+      patch.users.each do |id, user_grant|
+        users[id] = StoredGrant.new(user_grant, revision)
+        @ownership.delete({key, GrantKey.new(:user, id)})
+      end
+      @records[key] = InstallationRecord.new(key, Version.new(generation, revision), bot, users,
+        patch.webhook || previous.try(&.webhook))
+    end
+
+    def delete(key : InstallationKey, expected : Version) : InstallationRecord
+      current(key, expected)
+      @ownership.reject! { |pair, _| pair[0] == key }
+      @records[key] = InstallationRecord.new(key,
+        Version.new(expected.generation + 1, expected.revision + 1), deleted: true)
+    end
+
+    def invalidate(key : InstallationKey, grant : GrantKey, expected : Version) : InstallationRecord
+      old = current(key, expected)
+      users = old.users
+      bot = old.bot
+      if grant.kind.bot?
+        bot = nil
+      else
+        users.delete(grant.user_id)
+      end
+      @ownership.delete({key, grant})
+      @records[key] = InstallationRecord.new(key,
+        Version.new(expected.generation, expected.revision + 1), bot, users, old.webhook)
+    end
+
+    def acquire(query : InstallationQuery) : CredentialReference
+      record = active(query.owner)
+      grant = record.grant(query.grant) || raise ContractError.new(:missing_grant)
+      CredentialReference.new(query, record.version.generation, grant.revision)
+    end
+
+    def credential_for_dispatch(reference : CredentialReference) : Secret
+      grant = checked(reference)
+      status = refresh_status(reference.query)
+      raise ContractError.new(:unknown_remote_outcome) if status.try(&.phase.uncertain?)
+      raise ContractError.new(:refresh_busy) if status.try(&.phase.dispatched?)
+      raise ContractError.new(:reauthorization_required) if grant.expires_at.try { |expiry| expiry <= @clock.now }
+      grant.access_token
+    end
+
+    def claim_refresh(reference : CredentialReference, lease_duration : Time::Span) : RefreshLease
+      grant = checked(reference)
+      raise ContractError.new(:invalid_configuration) unless lease_duration > Time::Span.zero
+      raise ContractError.new(:reauthorization_required) unless grant.refresh_token
+      if status = refresh_status(reference.query)
+        raise ContractError.new(status.phase.uncertain? ? ErrorCode::UnknownRemoteOutcome : ErrorCode::RefreshBusy)
+      end
+      @fence += 1
+      lease = RefreshLease.new(reference, @fence, @clock.now + lease_duration)
+      @ownership[pair(reference)] = RefreshOwnership.new(lease, :acquired)
+      lease
+    end
+
+    def refresh_status(query : InstallationQuery) : RefreshOwnership?
+      key = {query.owner, query.grant}
+      if status = @ownership[key]?
+        if status.lease.expires_at <= @clock.now
+          if status.phase.acquired?
+            @ownership.delete(key)
+            return
+          end
+          status = RefreshOwnership.new(status.lease, :uncertain)
+          @ownership[key] = status
+        end
+        status
+      end
+    end
+
+    def mark_refresh_dispatched(lease : RefreshLease) : Nil
+      owned(lease, :acquired)
+      @ownership[pair(lease.credential)] = RefreshOwnership.new(lease, :dispatched)
+    end
+
+    def release_refresh(lease : RefreshLease) : Nil
+      owned(lease, :acquired)
+      @ownership.delete(pair(lease.credential))
+    end
+
+    def complete_refresh(lease : RefreshLease, replacement : Grant) : InstallationRecord
+      owned(lease, :dispatched)
+      reference = lease.credential
+      previous = checked(reference)
+      raise ContractError.new(:invalid_identity) unless previous.subject_id == replacement.subject_id
+      query = reference.query
+      patch = query.grant.kind.bot? ? InstallationPatch.new(bot: replacement) : InstallationPatch.new(users: {(query.grant.user_id || raise ContractError.new(:invalid_identity)) => replacement})
+      store(query.owner, patch, active(query.owner).version)
+    end
+
+    def fail_refresh(lease : RefreshLease, failure : RefreshFailure) : Nil
+      owned(lease, :dispatched)
+      if failure.rejected?
+        query = lease.credential.query
+        invalidate(query.owner, query.grant, active(query.owner).version)
+      else
+        @ownership[pair(lease.credential)] = RefreshOwnership.new(lease, :uncertain)
+      end
+    end
+
+    private def pair(reference : CredentialReference)
+      {reference.query.owner, reference.query.grant}
+    end
+
+    private def active(key : InstallationKey) : InstallationRecord
+      record = fetch(key)
+      raise ContractError.new(:missing_installation) if !record || record.deleted?
+      record
+    end
+
+    private def current(key : InstallationKey, expected : Version) : InstallationRecord
+      record = active(key)
+      raise ContractError.new(:conflict) unless record.version == expected
+      record
+    end
+
+    private def checked(reference : CredentialReference) : Grant
+      record = active(reference.query.owner)
+      grant = record.grant(reference.query.grant)
+      unless grant && record.version.generation == reference.generation && grant.revision == reference.grant_revision
+        raise ContractError.new(:conflict)
+      end
+      grant.grant
+    end
+
+    private def owned(lease : RefreshLease, phase : RefreshPhase) : Nil
+      checked(lease.credential)
+      status = refresh_status(lease.credential.query)
+      unless status && status.lease == lease && status.phase == phase && lease.expires_at > @clock.now
+        raise ContractError.new(:conflict)
+      end
+    end
+  end
+end

--- a/src/slack/auth/clock.cr
+++ b/src/slack/auth/clock.cr
@@ -1,0 +1,11 @@
+module Slack::Auth
+  abstract class Clock
+    abstract def now : Time
+  end
+
+  class SystemClock < Clock
+    def now : Time
+      Time.utc
+    end
+  end
+end

--- a/src/slack/auth/contracts.cr
+++ b/src/slack/auth/contracts.cr
@@ -1,0 +1,7 @@
+# Explicit entry point until shared package wiring is integrated.
+require "./clock"
+require "./errors"
+require "./state"
+require "./installation"
+require "./store"
+require "./transport"

--- a/src/slack/auth/errors.cr
+++ b/src/slack/auth/errors.cr
@@ -1,0 +1,45 @@
+module Slack::Auth
+  enum ErrorCode
+    InvalidConfiguration
+    InvalidIdentity
+    InvalidState
+    MissingInstallation
+    MissingGrant
+    Conflict
+    RefreshBusy
+    ReauthorizationRequired
+    UnknownRemoteOutcome
+    PersistenceFailure
+    TransportFailure
+    InvalidResponse
+    VerificationFailed
+  end
+
+  # Only allowlisted metadata belongs here; never attach a raw response or cause.
+  class ContractError < Exception
+    getter code : ErrorCode
+    getter http_status : Int32?
+    getter retry_after : Time::Span?
+
+    def initialize(@code : ErrorCode, @http_status : Int32? = nil, @retry_after : Time::Span? = nil)
+      super("Authentication failure: #{@code}")
+    end
+  end
+
+  # Secret values require explicit access and cannot leak through nested inspect.
+  struct Secret
+    getter value : String
+
+    def initialize(@value : String)
+      raise ContractError.new(ErrorCode::InvalidConfiguration) if @value.empty?
+    end
+
+    def inspect(io : IO) : Nil
+      io << "[REDACTED]"
+    end
+
+    def to_s(io : IO) : Nil
+      inspect(io)
+    end
+  end
+end

--- a/src/slack/auth/installation.cr
+++ b/src/slack/auth/installation.cr
@@ -1,0 +1,108 @@
+require "./errors"
+
+module Slack::Auth
+  enum InstallationKind
+    Workspace
+    Organization
+  end
+
+  struct InstallationKey
+    getter app_id : String
+    getter enterprise_id : String?
+    getter team_id : String?
+    getter kind : InstallationKind
+
+    def initialize(@app_id : String, @kind : InstallationKind, @enterprise_id : String? = nil, @team_id : String? = nil)
+      invalid = @app_id.empty? || @enterprise_id.try(&.empty?) || @team_id.try(&.empty?)
+      invalid ||= @kind.workspace? ? @team_id.nil? : (@enterprise_id.nil? || !@team_id.nil?)
+      raise ContractError.new(ErrorCode::InvalidIdentity) if invalid
+    end
+  end
+
+  enum TokenKind
+    Bot
+    User
+  end
+
+  struct GrantKey
+    getter kind : TokenKind
+    getter user_id : String?
+
+    def initialize(@kind : TokenKind, @user_id : String? = nil)
+      if @kind.bot? ? !@user_id.nil? : (@user_id.nil? || @user_id.try(&.empty?))
+        raise ContractError.new(ErrorCode::InvalidIdentity)
+      end
+    end
+  end
+
+  struct Grant
+    getter subject_id : String
+    getter access_token : Secret
+    getter refresh_token : Secret?
+    getter expires_at : Time?
+    @scopes : Array(String)
+
+    def initialize(@subject_id : String, @access_token : Secret, scopes : Array(String),
+                   @expires_at : Time? = nil, @refresh_token : Secret? = nil)
+      raise ContractError.new(ErrorCode::InvalidIdentity) if @subject_id.empty?
+      @scopes = scopes.dup
+    end
+
+    def scopes : Array(String)
+      @scopes.dup
+    end
+  end
+
+  record IncomingWebhook, url : Secret, channel_id : String, configuration_url : Secret? = nil
+  record Version, generation : Int64, revision : Int64
+  record StoredGrant, grant : Grant, revision : Int64
+
+  # A patch contains only grants received in this exchange; omitted grants survive.
+  struct InstallationPatch
+    getter bot : Grant?
+    getter webhook : IncomingWebhook?
+    @users : Hash(String, Grant)
+
+    def initialize(@bot : Grant? = nil, users : Hash(String, Grant) = {} of String => Grant,
+                   @webhook : IncomingWebhook? = nil)
+      users.each do |id, grant|
+        raise ContractError.new(ErrorCode::InvalidIdentity) if id.empty? || id != grant.subject_id
+      end
+      @users = users.dup
+    end
+
+    def users : Hash(String, Grant)
+      @users.dup
+    end
+  end
+
+  struct InstallationRecord
+    getter key : InstallationKey
+    getter version : Version
+    getter bot : StoredGrant?
+    getter webhook : IncomingWebhook?
+    getter? deleted : Bool
+    @users : Hash(String, StoredGrant)
+
+    def initialize(@key : InstallationKey, @version : Version, @bot : StoredGrant? = nil,
+                   users : Hash(String, StoredGrant) = {} of String => StoredGrant,
+                   @webhook : IncomingWebhook? = nil, @deleted : Bool = false)
+      @users = users.dup
+    end
+
+    def users : Hash(String, StoredGrant)
+      @users.dup
+    end
+
+    def grant(key : GrantKey) : StoredGrant?
+      key.kind.bot? ? @bot : @users[key.user_id]?
+    end
+  end
+
+  # owner must come from verified/trusted routing, never inferred from actor/visible team.
+  record InstallationQuery, owner : InstallationKey, grant : GrantKey,
+    actor_user_id : String? = nil, visible_team_id : String? = nil
+
+  # Request-local references contain a fence, not a cached reusable access token.
+  record CredentialReference, query : InstallationQuery, generation : Int64, grant_revision : Int64
+end

--- a/src/slack/auth/state.cr
+++ b/src/slack/auth/state.cr
@@ -1,0 +1,36 @@
+require "./clock"
+require "./errors"
+
+module Slack::Auth
+  enum AuthorizationPurpose
+    Installation
+    OIDC
+  end
+
+  struct AuthorizationAttempt
+    getter state : Secret
+    getter session_binding : Secret
+    getter purpose : AuthorizationPurpose
+    getter expires_at : Time
+    getter redirect_uri : String
+    getter nonce : Secret?
+
+    def initialize(@state : Secret, @session_binding : Secret, @purpose : AuthorizationPurpose,
+                   @expires_at : Time, @redirect_uri : String, @nonce : Secret? = nil)
+      if @redirect_uri.empty? || (@purpose.oidc? && @nonce.nil?) || (@purpose.installation? && !@nonce.nil?)
+        raise ContractError.new(ErrorCode::InvalidConfiguration)
+      end
+    end
+  end
+
+  abstract class StateStore
+    # The caller generates cryptographically random state and an OIDC nonce if needed.
+    # Insert a new attempt. On a collision, raise Conflict without replacing it.
+    abstract def issue(attempt : AuthorizationAttempt) : Nil
+
+    # Check state, session, purpose, and expiry, then delete the match atomically.
+    # Use the store clock. Reject expires_at <= now.
+    # On a mismatch, raise InvalidState without deleting the attempt.
+    abstract def consume(state : Secret, session_binding : Secret, purpose : AuthorizationPurpose) : AuthorizationAttempt
+  end
+end

--- a/src/slack/auth/store.cr
+++ b/src/slack/auth/store.cr
@@ -1,0 +1,57 @@
+require "./clock"
+require "./installation"
+
+module Slack::Auth
+  enum RefreshPhase
+    Acquired
+    Dispatched
+    Uncertain
+  end
+
+  record RefreshLease, credential : CredentialReference, fence : Int64, expires_at : Time
+  record RefreshOwnership, lease : RefreshLease, phase : RefreshPhase
+
+  enum RefreshFailure
+    Rejected
+    UnknownRemoteOutcome
+  end
+
+  abstract class InstallationStore
+    # Includes tombstones; nil means this key has never existed.
+    abstract def fetch(key : InstallationKey) : InstallationRecord?
+
+    # Atomic upsert with exact expected version (nil means insert-only).
+    # Active upsert preserves omitted grants; reinstall from tombstone advances generation.
+    abstract def store(key : InstallationKey, patch : InstallationPatch, expected : Version?) : InstallationRecord
+
+    # Retain tombstone and advance generation. Duplicate expected version => Conflict.
+    abstract def delete(key : InstallationKey, expected : Version) : InstallationRecord
+
+    # Remove only this grant, advancing its revision/fencing all of its refreshes.
+    abstract def invalidate(key : InstallationKey, grant : GrantKey, expected : Version) : InstallationRecord
+
+    abstract def acquire(query : InstallationQuery) : CredentialReference
+
+    # Atomic final validity check, immediately before each HTTP dispatch, including retry.
+    # Reject deleted/replaced/expired/uncertain grants. Never use cached token on failure.
+    abstract def credential_for_dispatch(reference : CredentialReference) : Secret
+
+    # All refresh methods are durable, atomic and cross-process, not process-local locks.
+    # Lease duration must be positive; the adapter owns authoritative time.
+    abstract def claim_refresh(reference : CredentialReference, lease_duration : Time::Span) : RefreshLease
+    abstract def refresh_status(query : InstallationQuery) : RefreshOwnership?
+
+    # Commit before network I/O. Once dispatched, expiry cannot authorize another request.
+    abstract def mark_refresh_dispatched(lease : RefreshLease) : Nil
+
+    # Only an unexpired Acquired owner may release (no HTTP request was sent).
+    abstract def release_refresh(lease : RefreshLease) : Nil
+
+    # Atomically persist replacement and release ownership; fence + generation + grant
+    # revision must still match and phase must be Dispatched with an unexpired lease.
+    abstract def complete_refresh(lease : RefreshLease, replacement : Grant) : InstallationRecord
+
+    # Rejected removes grant; unknown quarantines it. Both fence dispatch and retries.
+    abstract def fail_refresh(lease : RefreshLease, failure : RefreshFailure) : Nil
+  end
+end

--- a/src/slack/auth/transport.cr
+++ b/src/slack/auth/transport.cr
@@ -1,0 +1,60 @@
+require "http"
+require "uri"
+require "./errors"
+
+module Slack::Auth
+  # Feature-specific configs have no global environment reads or cross-feature requirements.
+  record APIConfiguration, base_uri : URI
+  record OAuthConfiguration, authorization_uri : URI, token_uri : URI,
+    client_id : String, client_secret : Secret, redirect_uri : URI
+  record OIDCConfiguration, discovery_uri : URI, issuer : String, client_id : String
+  record TransportOptions, connect_timeout : Time::Span = 10.seconds,
+    read_timeout : Time::Span = 30.seconds, write_timeout : Time::Span = 30.seconds,
+    proxy_uri : URI? = nil, ca_file : String? = nil
+
+  # Request/response contain secrets: no automatic logging or exception interpolation.
+  struct TransportRequest
+    getter method : String
+    getter uri : URI
+    getter headers : HTTP::Headers
+    getter body : String?
+
+    def initialize(@method : String, @uri : URI, @headers = HTTP::Headers.new, @body : String? = nil)
+    end
+
+    def inspect(io : IO) : Nil
+      io << "Slack::Auth::TransportRequest([REDACTED])"
+    end
+
+    def to_s(io : IO) : Nil
+      inspect(io)
+    end
+  end
+
+  struct TransportResponse
+    getter status : Int32
+    getter headers : HTTP::Headers
+    getter body : String
+
+    def initialize(@status : Int32, @headers : HTTP::Headers, @body : String)
+    end
+
+    def inspect(io : IO) : Nil
+      io << "Slack::Auth::TransportResponse(status=" << @status << ", [REDACTED])"
+    end
+
+    def to_s(io : IO) : Nil
+      inspect(io)
+    end
+  end
+
+  abstract class Transport
+    # Exactly one attempt; no implicit retries/redirects of credential-bearing requests.
+    # An ambiguous send raises UnknownRemoteOutcome, not retryable TransportFailure.
+    abstract def execute(request : TransportRequest) : TransportResponse
+  end
+
+  abstract class TransportFactory
+    abstract def build(options : TransportOptions) : Transport
+  end
+end


### PR DESCRIPTION
Authentication services need shared interfaces for state, installation storage, and token refresh. Add explicit Crystal contracts for these services, safe errors, clocks, and HTTP configuration.

The storage contract rejects stale refresh results after revocation or reinstall. It keeps bot and user grants separate and requires callers to resolve an uncertain refresh result before trying again. Synthetic test adapters show method usage and operation order. Production adapters and tests for restart and coordination across processes are separate work.

The guide explains these rules in focused sections with usage examples. It does not claim that the test adapters provide durable storage. Existing callers can continue to supply tokens directly to the API client.

Validation: 12 contract specs and all 55 specs passed during implementation and independent review. Format, lint, compile checks, and docs generation passed during implementation. The guide examples compile and run with synthetic adapters. The branch is rebased onto the agent guidelines in `next`; the guide and API comments were checked against those guidelines. No live Slack validation is claimed.
