### PR TITLE
Harden signed HTTP verification and timestamp boundaries

### DIFF
--- a/spec/webhooks/signature_spec.cr
+++ b/spec/webhooks/signature_spec.cr
@@ -1,0 +1,192 @@
+require "../spec_helper"
+
+module SignedRequestSpec
+  NOW    = Time.unix(1_700_000_000)
+  SECRET = "synthetic-signing-secret"
+  BODY   = "{ \"challenge\": \"snowman \\u2603\" }\n"
+  # Synthetic vector independently calculated with Python stdlib hmac/sha256:
+  # hmac.new(b'synthetic-signing-secret',
+  #   b'v0:1700000000:{ "challenge": "snowman \\u2603" }\n', hashlib.sha256)
+  SIGNATURE = "v0=464740e2abca0af4fd5c59f7c35b13f39b4fafc75c111e6487b037cfb91f05fd"
+
+  def self.request(body : String? = BODY, timestamp = NOW.to_unix.to_s, signature : String? = nil)
+    headers = HTTP::Headers{
+      "X-Slack-Request-Timestamp" => timestamp,
+      "X-Slack-Signature"         => signature || Slack::Webhooks::Signature.new(timestamp, body || "").compute,
+    }
+    HTTP::Request.new("POST", "/signed", headers, body)
+  end
+
+  def self.verify(request)
+    Slack::Webhooks::VerifiedRequest.new(request, clock: -> { NOW }).verify!
+  end
+end
+
+describe Slack::Webhooks::VerifiedRequest do
+  around_each do |example|
+    secret = Slack.settings.signing_secret
+    version = Slack.settings.signing_secret_version
+    limit = Slack.settings.webhook_delivery_time_limit
+    begin
+      Slack.configure do |settings|
+        settings.signing_secret = SignedRequestSpec::SECRET
+        settings.signing_secret_version = "v0"
+        settings.webhook_delivery_time_limit = 5.minutes
+      end
+      example.run
+    ensure
+      Slack.configure do |settings|
+        settings.signing_secret = secret
+        settings.signing_secret_version = version
+        settings.webhook_delivery_time_limit = limit
+      end
+    end
+  end
+
+  it "matches an independent fixed HMAC vector and retains exact bytes" do
+    Slack::Webhooks::Signature.new("1700000000", SignedRequestSpec::BODY).compute.should eq SignedRequestSpec::SIGNATURE
+    verified = SignedRequestSpec.verify(SignedRequestSpec.request(signature: SignedRequestSpec::SIGNATURE))
+    verified.body.to_slice.should eq SignedRequestSpec::BODY.to_slice
+    verified.verify!.body.should eq SignedRequestSpec::BODY
+  end
+
+  it "rejects changed body content and whitespace" do
+    [SignedRequestSpec::BODY.strip, SignedRequestSpec::BODY.sub("snowman", "tampered")].each do |body|
+      expect_raises(Slack::Errors::SignatureMismatch) do
+        SignedRequestSpec.verify(SignedRequestSpec.request(body, signature: SignedRequestSpec::SIGNATURE))
+      end
+    end
+  end
+
+  it "preserves non-ASCII, NUL, and CRLF bytes in a streamed body" do
+    body = "a=☃\u0000\r\n&b=%20+"
+    request = SignedRequestSpec.request(body)
+    request.body = IO::Memory.new(body)
+    SignedRequestSpec.verify(request).body.to_slice.should eq body.to_slice
+  end
+
+  [-300, 0, 300].each do |offset|
+    it "accepts the inclusive timestamp offset #{offset}" do
+      SignedRequestSpec.verify(SignedRequestSpec.request(timestamp: (SignedRequestSpec::NOW.to_unix + offset).to_s))
+    end
+  end
+
+  [-301, 301].each do |offset|
+    it "rejects timestamp offset #{offset}" do
+      expect_raises(Slack::Errors::ReplayAttack) do
+        SignedRequestSpec.verify(SignedRequestSpec.request(timestamp: (SignedRequestSpec::NOW.to_unix + offset).to_s))
+      end
+    end
+  end
+
+  it "honors a custom symmetric delivery limit" do
+    Slack.configure(&.webhook_delivery_time_limit = 10.seconds)
+    [-10, 10].each do |offset|
+      SignedRequestSpec.verify(SignedRequestSpec.request(timestamp: (SignedRequestSpec::NOW.to_unix + offset).to_s))
+    end
+    [-11, 11].each do |offset|
+      expect_raises(Slack::Errors::ReplayAttack) do
+        SignedRequestSpec.verify(SignedRequestSpec.request(timestamp: (SignedRequestSpec::NOW.to_unix + offset).to_s))
+      end
+    end
+  end
+
+  ["", "abc", "1700000000junk", "1700000000.0", " 1700000000", "+1700000000", "-1", "99999999999999999999999", Int64::MAX.to_s].each do |timestamp|
+    it "normalizes invalid timestamp #{timestamp.inspect}" do
+      error = expect_raises(Slack::Errors::InvalidWebhookRequest) do
+        SignedRequestSpec.verify(SignedRequestSpec.request(timestamp: timestamp))
+      end
+      error.reason.should eq :malformed_timestamp
+    end
+  end
+
+  ["", "v1=#{"a" * 64}", "v0=#{"a" * 63}", "v0=#{"a" * 65}", "v0=#{"g" * 64}", "v0=#{"A" * 64}", "v0=#{"a" * 64} "].each do |signature|
+    it "rejects malformed signature #{signature.inspect}" do
+      error = expect_raises(Slack::Errors::InvalidWebhookRequest) do
+        SignedRequestSpec.verify(SignedRequestSpec.request(signature: signature))
+      end
+      error.reason.should eq :malformed_signature
+    end
+  end
+
+  {"X-Slack-Signature" => :missing_signature, "X-Slack-Request-Timestamp" => :missing_timestamp}.each do |header, reason|
+    it "normalizes missing #{header}" do
+      request = SignedRequestSpec.request
+      request.headers.delete(header)
+      expect_raises(Slack::Errors::InvalidWebhookRequest) { SignedRequestSpec.verify(request) }.reason.should eq reason
+    end
+
+    it "rejects duplicate #{header}" do
+      request = SignedRequestSpec.request
+      request.headers.add(header, request.headers[header])
+      expect_raises(Slack::Errors::InvalidWebhookRequest) { SignedRequestSpec.verify(request) }
+    end
+  end
+
+  it "rejects missing and empty bodies with stable errors" do
+    expect_raises(Slack::Errors::InvalidWebhookRequest) { SignedRequestSpec.verify(SignedRequestSpec.request(nil)) }.reason.should eq :missing_body
+    request = SignedRequestSpec.request
+    request.body = IO::Memory.new
+    expect_raises(Slack::Errors::InvalidWebhookRequest) { SignedRequestSpec.verify(request) }.reason.should eq :empty_body
+  end
+
+  it "does not enable another protocol through the legacy version setting" do
+    Slack.configure(&.signing_secret_version = "v1")
+    expect_raises(Slack::Errors::InvalidWebhookRequest) { SignedRequestSpec.verify(SignedRequestSpec.request) }
+  end
+
+  it "rejects validly shaped incorrect digests" do
+    expect_raises(Slack::Errors::SignatureMismatch, "Slack webhook signature mismatch") do
+      SignedRequestSpec.verify(SignedRequestSpec.request(signature: "v0=#{"0" * 64}"))
+    end
+  end
+
+  it "verifies raw JSON and form bytes through every process entry point" do
+    timestamp = Time.utc.to_unix.to_s
+    Slack.process_webhook(SignedRequestSpec.request(File.read("spec/fixtures/events/url_verification.json"), timestamp)).should be_a Slack::UrlVerification
+    form = File.read("spec/fixtures/commands/encoded_names.txt")
+    Slack.process_command(SignedRequestSpec.request(form, timestamp)).should be_a Slack::Command
+    interaction = "payload=%7B%20%22type%22%3A%20%22shortcut%22%20%7D"
+    Slack.process_interaction(SignedRequestSpec.request(interaction, timestamp)).should be_a Slack::Interactions::Shortcut
+  end
+
+  it "verifies before parsing through every process entry point" do
+    timestamp = Time.utc.to_unix.to_s
+    expect_raises(Slack::Errors::SignatureMismatch) { Slack.process_webhook(SignedRequestSpec.request("invalid json", timestamp, "v0=#{"0" * 64}")) }
+    expect_raises(Slack::Errors::SignatureMismatch) { Slack.process_command(SignedRequestSpec.request("invalid form", timestamp, "v0=#{"0" * 64}")) }
+    expect_raises(Slack::Errors::SignatureMismatch) { Slack.process_interaction(SignedRequestSpec.request("no payload", timestamp, "v0=#{"0" * 64}")) }
+  end
+  it "rejects whitespace and equivalent form re-encoding through the process entry points" do
+    timestamp = Time.utc.to_unix.to_s
+    json = File.read("spec/fixtures/events/url_verification.json")
+    request = SignedRequestSpec.request(json, timestamp)
+    request.body = IO::Memory.new(json + " ")
+    expect_raises(Slack::Errors::SignatureMismatch) { Slack.process_webhook(request) }
+
+    form = File.read("spec/fixtures/commands/encoded_names.txt")
+    request = SignedRequestSpec.request(form, timestamp)
+    request.body = IO::Memory.new(form + "&")
+    expect_raises(Slack::Errors::SignatureMismatch) { Slack.process_command(request) }
+
+    form = "payload=%7B%22type%22%3A%22shortcut%22%7D"
+    request = SignedRequestSpec.request(form, timestamp)
+    request.body = IO::Memory.new(form.sub("%7B", "%7b"))
+    expect_raises(Slack::Errors::SignatureMismatch) { Slack.process_interaction(request) }
+  end
+
+  it "normalizes missing inputs through every process entry point" do
+    expect_raises(Slack::Errors::InvalidWebhookRequest) { Slack.process_webhook(HTTP::Request.new("POST", "/")) }
+    expect_raises(Slack::Errors::InvalidWebhookRequest) { Slack.process_command(HTTP::Request.new("POST", "/")) }
+    expect_raises(Slack::Errors::InvalidWebhookRequest) { Slack.process_interaction(HTTP::Request.new("POST", "/")) }
+  end
+
+  it "normalizes IO failures without exposing their messages" do
+    request = SignedRequestSpec.request
+    stream = IO::Memory.new("secret body")
+    stream.close
+    request.body = stream
+    error = expect_raises(Slack::Errors::InvalidWebhookRequest) { SignedRequestSpec.verify(request) }
+    error.reason.should eq :unreadable_body
+    error.message.should eq "Invalid Slack webhook request: unreadable_body"
+  end
+end

--- a/src/slack/errors/invalid_webhook_request.cr
+++ b/src/slack/errors/invalid_webhook_request.cr
@@ -1,0 +1,11 @@
+require "./signature_mismatch"
+
+# Malformed signed-request inputs. Messages never include request data or secrets.
+# Inherits SignatureMismatch so existing verification failure handlers still work.
+class Slack::Errors::InvalidWebhookRequest < Slack::Errors::SignatureMismatch
+  getter reason : Symbol
+
+  def initialize(@reason : Symbol)
+    super("Invalid Slack webhook request: #{reason}")
+  end
+end

--- a/src/slack/errors/signature_mismatch.cr
+++ b/src/slack/errors/signature_mismatch.cr
@@ -1,5 +1,5 @@
 class Slack::Errors::SignatureMismatch < Exception
-  def initialize
-    super("Slack webhook signature mismatch")
+  def initialize(message : String = "Slack webhook signature mismatch")
+    super(message)
   end
 end

--- a/src/slack/webhooks/verified_request.cr
+++ b/src/slack/webhooks/verified_request.cr
@@ -1,4 +1,6 @@
-# https://api.slack.com/authentication/verifying-requests-from-slack
+require "crypto/subtle"
+
+# Verifies the original body before any JSON or form decoding.
 struct Slack::Webhooks::VerifiedRequest
   getter request : HTTP::Request
   getter slack_signature : String
@@ -9,28 +11,62 @@ struct Slack::Webhooks::VerifiedRequest
   delegate signing_secret_version, to: Slack.settings
   delegate webhook_delivery_time_limit, to: Slack.settings
 
-  def initialize(@request : HTTP::Request)
-    @slack_timestamp = @request.headers["X-Slack-Request-Timestamp"]
-    @slack_signature = @request.headers["X-Slack-Signature"]
+  # Callers can supply a fixed UTC clock for tests.
+  # Read the request body once. Keep its exact bytes in #body.
+  def initialize(@request : HTTP::Request, @clock : Proc(Time) = -> { Time.utc })
+    @slack_timestamp = header("X-Slack-Request-Timestamp", :missing_timestamp, :malformed_timestamp)
+    @slack_signature = header("X-Slack-Signature", :missing_signature, :malformed_signature)
+    body_io = @request.body || raise Errors::InvalidWebhookRequest.new(:missing_body)
+    @body = read_body(body_io)
+    raise Errors::InvalidWebhookRequest.new(:empty_body) if @body.empty?
+  end
 
-    # ameba:disable Lint/NotNil
-    @body = @request.body.not_nil!.gets_to_end
-    # ameba:enable Lint/NotNil
+  private def read_body(io : IO) : String
+    io.gets_to_end
+  rescue IO::Error
+    raise Errors::InvalidWebhookRequest.new(:unreadable_body)
   end
 
   def verify!
     raise Errors::ReplayAttack.new if replay_attack?
+    validate_signature!
     raise Errors::SignatureMismatch.new unless signature_matches?
     self
   end
 
   def signature_matches?
-    slack_signature == Signature
-      .new(slack_timestamp: slack_timestamp, body: body)
-      .compute
+    return false unless valid_signature?
+    Crypto::Subtle.constant_time_compare(slack_signature, Signature.new(slack_timestamp, body).compute)
   end
 
+  # Accept timestamps at both exact limits. This check does not remove duplicate events.
   def replay_attack?
-    Time.unix(slack_timestamp.to_i) < webhook_delivery_time_limit.ago
+    timestamp = parsed_timestamp
+    now = @clock.call
+    timestamp < now - webhook_delivery_time_limit || timestamp > now + webhook_delivery_time_limit
+  end
+
+  private def header(name : String, missing : Symbol, malformed : Symbol) : String
+    values = @request.headers.get?(name)
+    raise Errors::InvalidWebhookRequest.new(missing) unless values
+    raise Errors::InvalidWebhookRequest.new(malformed) if values.size != 1 || values.first.empty?
+    values.first
+  end
+
+  private def parsed_timestamp : Time
+    unless /\A[0-9]+\z/.matches?(slack_timestamp) && (seconds = slack_timestamp.to_i64?)
+      raise Errors::InvalidWebhookRequest.new(:malformed_timestamp)
+    end
+    Time.unix(seconds)
+  rescue ArgumentError | OverflowError
+    raise Errors::InvalidWebhookRequest.new(:malformed_timestamp)
+  end
+
+  private def valid_signature? : Bool
+    signing_secret_version == "v0" && /\Av0=[0-9a-f]{64}\z/.matches?(slack_signature)
+  end
+
+  private def validate_signature!
+    raise Errors::InvalidWebhookRequest.new(:malformed_signature) unless valid_signature?
   end
 end


### PR DESCRIPTION
Reject malformed signatures and requests outside the configured timestamp window. The default window accepts timestamps within five minutes before or after the current time, including the exact limits.

Use constant-time signature comparison, explicit v0 validation, predictable input errors, and an injectable clock. Preserve the original request bytes for processing. Rejecting far-future requests and changing malformed-input errors are intentional compatibility changes.

Validation: all 80 specs, format, lint, and docs generation passed during implementation. Independent review found no actionable defects and passed 37 dedicated signature specs plus the full suite. The branch is rebased onto the agent guidelines in `next`; its added API comments use short, direct sentences.

Adoption of the shared clock interface is a later integration change. Live Slack validation remains pending. This change does not add a receiver or duplicate-event handling.
