### PR TITLE
Reject unchecked OIDC identities explicitly

### DIFF
--- a/spec/oidc_guard_spec.cr
+++ b/spec/oidc_guard_spec.cr
@@ -1,0 +1,59 @@
+require "spec"
+require "base64"
+require "../src/slack/oauth/sign_in_response"
+
+describe Slack::SignInResponse do
+  # Synthetic wire claims, not evidence of authenticated identity. No JWT shard
+  # or shared spec helper is loaded: the public guard must compile on its own.
+  claims = {
+    "at_hash"                       => "unchecked-access-hash",
+    "email"                         => "person@example.test",
+    "family_name"                   => "Example",
+    "given_name"                    => "Person",
+    "iss"                           => "https://slack.com",
+    "locale"                        => "en-US",
+    "name"                          => "Person Example",
+    "nonce"                         => "unchecked-nonce",
+    "picture"                       => "https://example.test/avatar.png",
+    "sub"                           => "U_TEST",
+    "email_verified"                => true,
+    "aud"                           => "test-client",
+    "auth_time"                     => 1_800_000_000,
+    "date_email_verified"           => 1_800_000_000,
+    "exp"                           => 4_000_000_000_i64,
+    "iat"                           => 1_800_000_000,
+    "https://slack.com/team_domain" => "example",
+    "https://slack.com/team_id"     => "T_TEST",
+    "https://slack.com/team_name"   => "Example",
+    "https://slack.com/user_id"     => "U_TEST",
+  }
+  payload = Base64.urlsafe_encode(claims.to_json, padding: false)
+  unsigned_header = Base64.urlsafe_encode(%({"alg":"none"}), padding: false)
+  signed_header = Base64.urlsafe_encode(%({"alg":"RS256","kid":"unknown"}), padding: false)
+
+  {
+    "unsigned JWT with complete identity claims" => "#{unsigned_header}.#{payload}.",
+    "JWT with an unchecked signature"            => "#{signed_header}.#{payload}.ZmFrZQ",
+    "malformed token"                            => "secret-id-token",
+    "empty token"                                => "",
+  }.each do |scenario, token|
+    it "rejects a #{scenario} with an explicit authentication error" do
+      response = Slack::SignInResponse.from_json({
+        ok:           true,
+        access_token: "secret-access-token",
+        id_token:     token,
+        token_type:   "Bearer",
+      }.to_json)
+
+      error = expect_raises(Slack::SignInResponse::VerificationUnavailable,
+        "Sign in with Slack is unavailable: OIDC identity verification is not implemented") do
+        response.decoded_response
+      end
+
+      error.should be_a(Slack::Errors::Auth)
+      error.message.to_s.should_not contain("secret-access-token")
+      error.message.to_s.should_not contain("secret-id-token")
+      error.message.to_s.should_not contain(payload)
+    end
+  end
+end

--- a/src/slack/oauth/sign_in_response.cr
+++ b/src/slack/oauth/sign_in_response.cr
@@ -1,6 +1,17 @@
+require "json"
+require "../errors/auth"
+
 struct Slack::SignInResponse
   include JSON::Serializable
 
+  # Login is unavailable until full OIDC verification is implemented.
+  class VerificationUnavailable < Errors::Auth
+    def initialize
+      super("Sign in with Slack is unavailable: OIDC identity verification is not implemented")
+    end
+  end
+
+  # These fields contain claims from a response. Parsing them does not authenticate a user.
   struct DecodedResponse
     include JSON::Serializable
 
@@ -45,10 +56,9 @@ struct Slack::SignInResponse
 
   property? ok = true
 
-  def decoded_response
-    DecodedResponse.from_json(
-      JWT.decode(id_token, verify: false, validate: false)[0].to_json
-    )
+  # Never expose unchecked ID-token claims as an authenticated identity.
+  def decoded_response : NoReturn
+    raise VerificationUnavailable.new
   end
 
   def self.from_json(json : String | IO)


### PR DESCRIPTION
Sign in with Slack currently decodes identity tokens without checking their signatures or claims. Make `decoded_response` raise a typed authentication error instead of returning an unchecked identity. The error message contains no token data.

Login is intentionally unavailable until full OIDC verification is implemented. Parsed claims remain data and do not establish an authenticated identity. Entry-point repairs and README corrections are a separate change.

Validation: four dedicated specs and all 47 specs passed during implementation and independent review. Scoped format and lint checks passed during implementation. The reviewer also checked public callback paths with an injected fake client. The branch is rebased onto the agent guidelines in `next`; its added API comments use short, direct sentences.

One initial review probe failed to intercept an HTTP overload and sent dummy credentials to Slack. No real credentials were used. The corrected fake passed; the accidental request is not live validation evidence.
