### PR TITLE
Give coding agents shared Crystal and contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Guidelines
+
+Follow these guidelines when working on this Crystal project.
+
+## Best Practices
+
+- Favor explicit type signatures over implicit types.
+- Use compile-time type checking as much as possible.
+- Use `#as` casts only when absolutely necessary.
+- Handle nil cases with `#try` or proper nil checks.
+- Use unions, such as `String | Nil`, instead of loose typing.
+
+## Concurrency
+
+- Use fibers for concurrent operations, not threads.
+- Properly close channels when done.
+- Use `select` for channel multiplexing.
+- Document fiber lifecycle and synchronization.
+- Avoid race conditions with proper mutex usage.
+
+## Project Documentation
+
+- Be concise and clear.
+- Organize the README into separate, focused sections. Avoid lengthy, unreadable documentation.
+- Use examples liberally to illustrate concepts.
+- Use ASD-STE100 Simplified Technical English to produce documentation that is readable by humans.
+
+## Commit Messages and Pull Requests
+
+- Make commit subjects, commit messages, PR titles, and PR descriptions meaningful on their own. Readers should not need the conversation or task history to understand them.
+- Describe what changes and the impact of the change in clear, human-readable language.
+- Do not use prefixes such as `fix:`, `feat:`, or `docs:`. Use a descriptive subject or title instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Give coding agents shared instructions for Crystal type safety, nil handling, fiber concurrency, and clear project documentation using ASD-STE100. Link `CLAUDE.md` to `AGENTS.md` so Codex and Claude use the same guidance.

Require commit subjects, messages, PR titles, and descriptions to explain changes and their impact in human-readable language. They must make sense without task or conversation history and must avoid category prefixes such as `fix:`, `feat:`, and `docs:`.

Validation: checked the diff for whitespace errors and verified the relative `CLAUDE.md` symlink resolves to `AGENTS.md`. No runtime tests were needed for these instruction-only changes.
